### PR TITLE
Fixes for upcoming mypy 0.900

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ def main():
             "pytools>=2020.4.1",
             "pytest>=2.3",
             "loopy>=2019.1",
-            "dataclasses; python_version<='3.6'",
+            "dataclasses; python_version<'3.7'",
+            "types-dataclasses",
         ],
         package_data={"arraycontext": ["py.typed"]},
     )


### PR DESCRIPTION
According to
https://mypy-lang.blogspot.com/2021/05/the-upcoming-switch-to-modular-typeshed.html
mypy has unbundled a lot of their type stubs, so those need to be installed separately.

There seems to be a `--install-types` command
https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-install-types
that does this automatically, but the docs say it only installs a vetted set of packages. Haven't really tested this either.