### PR TITLE
Improve array context mismatch error for frozen operands

### DIFF
--- a/arraycontext/container/arithmetic.py
+++ b/arraycontext/container/arithmetic.py
@@ -330,8 +330,18 @@ def with_container_arithmetic(
                     if __debug__ and _cls_has_array_context_attr:
                         gen("""
                             if arg1.array_context is not arg2.array_context:
-                                raise ValueError("array contexts of both arguments "
-                                    "must match")""")
+                                msg = ("array contexts of both arguments "
+                                    "must match")
+                                if arg1.array_context is None:
+                                    raise ValueError(msg
+                                        + ": left operand is frozen "
+                                        "(i.e. has no array context)")
+                                elif arg2.array_context is None:
+                                    raise ValueError(msg
+                                        + ": right operand is frozen "
+                                        "(i.e. has no array context)")
+                                else:
+                                    raise ValueError(msg)""")
                     gen(f"return cls({zip_init_args})")
                 gen(f"""
                 if {bool(outer_bcast_type_names)}:  # optimized away

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -627,6 +627,12 @@ def test_container_freeze_thaw(actx_factory):
 
     actx2 = actx.clone()
 
+    ary_dof_frozen = freeze(ary_dof)
+    with pytest.raises(ValueError) as exc_info:
+        ary_dof + ary_dof_frozen
+
+    assert "frozen" in str(exc_info.value)
+
     ary_dof_2 = thaw(freeze(ary_dof), actx2)
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
This improves the "array context mismatch" error to be more helpful if one of the operands is frozen.

cc @mtcam