### PR TITLE
Kernel transform strategy based on iname tags

### DIFF
--- a/arraycontext/loopy.py
+++ b/arraycontext/loopy.py
@@ -39,7 +39,7 @@ _DEFAULT_LOOPY_OPTIONS = lp.Options(
 
 
 def make_loopy_program(domains, statements, kernel_data=None,
-        name="mm_actx_kernel"):
+        name="mm_actx_kernel", tags=None):
     """Return a :class:`loopy.LoopKernel` suitable for use with
     :meth:`ArrayContext.call_loopy`.
     """
@@ -53,7 +53,8 @@ def make_loopy_program(domains, statements, kernel_data=None,
             options=_DEFAULT_LOOPY_OPTIONS,
             default_offset=lp.auto,
             name=name,
-            lang_version=MOST_RECENT_LANGUAGE_VERSION)
+            lang_version=MOST_RECENT_LANGUAGE_VERSION,
+            tags=tags)
 
 
 def get_default_entrypoint(t_unit):

--- a/arraycontext/metadata.py
+++ b/arraycontext/metadata.py
@@ -1,6 +1,8 @@
 """
 .. autoclass:: CommonSubexpressionTag
 .. autoclass:: FirstAxisIsElementsTag
+.. autoclass:: ElementInameTag
+.. autoclass:: DOFInameTag
 """
 
 __copyright__ = """
@@ -39,11 +41,24 @@ class CommonSubexpressionTag(Tag):
     """
 
 
+# FIXME: These should probably move to meshmode at some point
 class FirstAxisIsElementsTag(Tag):
     """A tag that is applicable to array outputs indicating that the
     first index corresponds to element indices. This suggests that
     the implementation should set element indices as the outermost
     loop extent.
+    """
+
+
+class ElementInameTag(Tag):
+    """A tag applicable to an iname indicating that this iname is used to
+    iterate over elements in a discretization.
+    """
+
+
+class DOFInameTag(Tag):
+    """A tag applicable to an iname indicating that this iname is used to
+    iterate over degrees of freedom within an element in a discretization.
     """
 
 # }}}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ git+https://github.com/inducer/pymbolic.git#egg=pymbolic
 git+https://github.com/inducer/pyopencl.git#egg=pyopencl
 git+https://github.com/inducer/islpy.git#egg=islpy
 
-git+https://github.com/inducer/loopy.git#egg=loopy
+git+https://github.com/inducer/loopy.git@iname-tags#egg=loopy
 git+https://github.com/inducer/pytato.git#egg=pytato

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ git+https://github.com/inducer/pymbolic.git#egg=pymbolic
 git+https://github.com/inducer/pyopencl.git#egg=pyopencl
 git+https://github.com/inducer/islpy.git#egg=islpy
 
-git+https://github.com/inducer/loopy.git@iname-tags#egg=loopy
+git+https://github.com/inducer/loopy.git#egg=loopy
 git+https://github.com/inducer/pytato.git#egg=pytato


### PR DESCRIPTION
This is intended to help revive https://github.com/inducer/meshmode/pull/217. It's used in https://github.com/inducer/meshmode/pull/220.

I'm not sure this has any business being here, but I didn't have the stamina to give meshmode its own `PyOpenCLArrayContext` subclass again. Nonetheless, I think that's what we should do. @matthiasdiener, I'd be grateful for your help here.

 That means:
- updating those imports across the tests and examples (in meshmode), and
- making the pytest fixture customizable as to what actx classes to use,
- Same goes for grudge and mirgecom, as they will likely grow their own kernel metadata at some point. 
- This also makes the other transform strategies redundant, so those can really go. (and the other meshmode kernels should be updated to use this one)
- So `PyOpenCLArrayContext.transform_loopy` here should really just raise. To still be able to run tests for this package, introduce a subclass that has a no-op `transform_loopy`.
-  To avoid a huge performance pitfall, it's important that the array context provides a useful error if no applicable transform strategy was found.

Draft because:
- [x] Needs https://github.com/inducer/loopy/pull/410
- [x] Point `requirements.txt` back to `main`
- [ ] Should really live in meshmode.

cc @thomasgibson @alexfikl 