### PR TITLE
Mimic numpy's norm when ord is None

### DIFF
--- a/arraycontext/impl/pyopencl.py
+++ b/arraycontext/impl/pyopencl.py
@@ -155,9 +155,9 @@ def _flatten_array(ary):
         return ary._new_with_changes(
                 data=None, offset=0, shape=(0,), strides=(ary.dtype.itemsize,))
     if ary.flags.f_contiguous:
-        return ary.ravel(order="F")
+        return ary.reshape(-1, order="F")
     elif ary.flags.c_contiguous:
-        return ary.ravel(order="C")
+        return ary.reshape(-1, order="C")
     else:
         raise ValueError("cannot flatten array "
                 f"with strides {ary.strides} of {ary.dtype}")

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -702,6 +702,23 @@ def test_norm_complex(actx_factory, norm_ord):
     assert abs(norm_a_ref - norm_a)/norm_a < 1e-13
 
 
+@pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])
+def test_norm_ord_none(actx_factory, ndim):
+    from numpy.random import default_rng
+
+    actx = actx_factory()
+
+    rng = default_rng()
+    shape = tuple(rng.integers(2, 7, ndim))
+
+    a = rng.random(shape)
+
+    norm_a_ref = np.linalg.norm(a, ord=None)
+    norm_a = actx.np.linalg.norm(actx.from_numpy(a), ord=None)
+
+    np.testing.assert_allclose(norm_a, norm_a_ref)
+
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:


### PR DESCRIPTION
- When ord is None, numpy ravels the array and then computes the euclidean norm.

I couldn't find a mention for this in the numpy docs, but here is a small script:
```python
In [2]: a = np.random.rand(3, 3, 3, 3, 3)

In [3]: np.linalg.norm(a)
Out[3]: 8.718438810223871

In [4]: np.linalg.norm(a.ravel(), ord=2)
Out[4]: 8.718438810223871
```

Let me know what do you guys think.

