### PR TITLE
Add a flag to indicate whether an array context permits in-place modification

### DIFF
--- a/arraycontext/context.py
+++ b/arraycontext/context.py
@@ -103,7 +103,7 @@ THE SOFTWARE.
 """
 
 from typing import Sequence, Union
-from abc import ABC, abstractmethod
+from abc import ABC, abstractmethod, abstractproperty
 
 import numpy as np
 from pytools import memoize_method
@@ -348,6 +348,11 @@ class ArrayContext(ABC):
             it becomes easier to detect and flag if unfrozen data attached to a
             "setup-only" array context "leaks" into the application.
         """
+
+    # undocumented for now
+    @abstractproperty
+    def permits_inplace_modification(self):
+        pass
 
 # }}}
 

--- a/arraycontext/impl/pyopencl.py
+++ b/arraycontext/impl/pyopencl.py
@@ -436,6 +436,9 @@ class PyOpenCLArrayContext(ArrayContext):
     def clone(self):
         return type(self)(self.queue, self.allocator, self._wait_event_queue_length)
 
+    def permits_inplace_modification(self):
+        return True
+
 # }}}
 
 # vim: foldmethod=marker


### PR DESCRIPTION
The context for this is that some operations, specifically the `DirectConnection` kernels of https://github.com/inducer/meshmode/pull/220, benefit quite a bit from being able to do in-place updates, see https://github.com/inducer/meshmode/pull/220#issuecomment-861927006. So the idea would be to include both code paths and use in-place updates only if allowed. For testing, we'd of course make a way to force both code paths to be used. Adding this feels a bit ad-hoc, OTOH I think it's quite possibly a reasonable thing for an array context to tell a user.

cc @thomasgibson 