### PR TITLE
Extend pytest_generate_tests_for

### DIFF
--- a/.pylintrc-local.yml
+++ b/.pylintrc-local.yml
@@ -1,8 +1,0 @@
-- arg: ignore
-  val:
-    - firedrake
-    - to_firedrake.py
-    - from_firedrake.py
-    - test_firedrake_interop.py
-- arg: extension-pkg-whitelist
-  val: mayavi

--- a/arraycontext/__init__.py
+++ b/arraycontext/__init__.py
@@ -53,7 +53,8 @@ from .container.traversal import (
 from .impl.pyopencl import PyOpenCLArrayContext
 
 from .pytest import (
-        pytest_generate_tests_for_array_context,
+        PytestArrayContextFactory,
+        pytest_generate_tests_for_array_contexts,
         pytest_generate_tests_for_pyopencl_array_context)
 
 from .loopy import make_loopy_program
@@ -83,7 +84,8 @@ __all__ = (
 
         "make_loopy_program",
 
-        "pytest_generate_tests_for_array_context",
+        "PytestArrayContextFactory",
+        "pytest_generate_tests_for_array_contexts",
         "pytest_generate_tests_for_pyopencl_array_context"
         )
 

--- a/arraycontext/__init__.py
+++ b/arraycontext/__init__.py
@@ -52,7 +52,9 @@ from .container.traversal import (
 
 from .impl.pyopencl import PyOpenCLArrayContext
 
-from .pytest import pytest_generate_tests_for_pyopencl_array_context
+from .pytest import (
+        pytest_generate_tests_for_array_context,
+        pytest_generate_tests_for_pyopencl_array_context)
 
 from .loopy import make_loopy_program
 
@@ -81,6 +83,7 @@ __all__ = (
 
         "make_loopy_program",
 
+        "pytest_generate_tests_for_array_context",
         "pytest_generate_tests_for_pyopencl_array_context"
         )
 

--- a/arraycontext/impl/pyopencl/__init__.py
+++ b/arraycontext/impl/pyopencl/__init__.py
@@ -156,8 +156,7 @@ class PyOpenCLArrayContext(ArrayContext):
         return cl_array.to_device(self.queue, array, allocator=self.allocator)
 
     def to_numpy(self, array):
-        from numbers import Number
-        if not self._force_device_scalars and isinstance(array, Number):
+        if not self._force_device_scalars and np.isscalar(array):
             return array
 
         return array.get(queue=self.queue)

--- a/arraycontext/impl/pyopencl/__init__.py
+++ b/arraycontext/impl/pyopencl/__init__.py
@@ -28,7 +28,7 @@ THE SOFTWARE.
 """
 
 from warnings import warn
-from typing import Any, Dict, List, Sequence, Optional, Union, TYPE_CHECKING
+from typing import Dict, List, Sequence, Optional, Union, TYPE_CHECKING
 
 import numpy as np
 
@@ -117,7 +117,7 @@ class PyOpenCLArrayContext(ArrayContext):
 
         self._force_device_scalars = force_device_scalars
         self._wait_event_queue_length = wait_event_queue_length
-        self._kernel_name_to_wait_event_queue: Dict[str, List[Any]] = {}
+        self._kernel_name_to_wait_event_queue: Dict[str, List[cl.Event]] = {}
 
         if queue.device.type & cl.device_type.GPU:
             if allocator is None:

--- a/arraycontext/impl/pyopencl/__init__.py
+++ b/arraycontext/impl/pyopencl/__init__.py
@@ -133,7 +133,7 @@ class PyOpenCLArrayContext(ArrayContext):
                         "a noticeable speed improvement.")
 
         self._loopy_transform_cache: \
-                Dict[lp.TranslationUnit, lp.TranslationUnit] = {}
+                Dict["lp.TranslationUnit", "lp.TranslationUnit"] = {}
 
     def _get_fake_numpy_namespace(self):
         from arraycontext.impl.pyopencl.fake_numpy import PyOpenCLFakeNumpyNamespace

--- a/arraycontext/impl/pyopencl/__init__.py
+++ b/arraycontext/impl/pyopencl/__init__.py
@@ -2,6 +2,7 @@
 .. currentmodule:: arraycontext
 .. autoclass:: PyOpenCLArrayContext
 """
+
 __copyright__ = """
 Copyright (C) 2020-1 University of Illinois Board of Trustees
 """
@@ -27,7 +28,7 @@ THE SOFTWARE.
 """
 
 from warnings import warn
-from typing import Sequence, Union
+from typing import Any, Dict, List, Sequence, Optional, Union, TYPE_CHECKING
 
 import numpy as np
 
@@ -35,6 +36,10 @@ from pytools.tag import Tag
 
 from arraycontext.metadata import FirstAxisIsElementsTag
 from arraycontext.context import ArrayContext
+
+
+if TYPE_CHECKING:
+    import pyopencl
 
 
 # {{{ PyOpenCLArrayContext
@@ -62,7 +67,11 @@ class PyOpenCLArrayContext(ArrayContext):
         as the allocator can help avoid this cost.
     """
 
-    def __init__(self, queue, allocator=None, wait_event_queue_length=None):
+    def __init__(self,
+            queue: "pyopencl.CommandQueue",
+            allocator: Optional["pyopencl.tools.AllocatorInterface"] = None,
+            wait_event_queue_length: Optional[int] = None,
+            force_device_scalars: bool = False) -> None:
         r"""
         :arg wait_event_queue_length: The length of a queue of
             :class:`~pyopencl.Event` objects that are maintained by the
@@ -84,18 +93,24 @@ class PyOpenCLArrayContext(ArrayContext):
             For now, *wait_event_queue_length* should be regarded as an
             experimental feature that may change or disappear at any minute.
         """
+        if not force_device_scalars:
+            warn("Returning host scalars from the array context is deprecated. "
+                    "To return device scalars set 'force_device_scalars=True'. "
+                    "Support for returning host scalars will be removed in 2022.",
+                    DeprecationWarning, stacklevel=2)
+
         import pyopencl as cl
 
         super().__init__()
         self.context = queue.context
         self.queue = queue
         self.allocator = allocator if allocator else None
-
         if wait_event_queue_length is None:
             wait_event_queue_length = 10
 
+        self._force_device_scalars = force_device_scalars
         self._wait_event_queue_length = wait_event_queue_length
-        self._kernel_name_to_wait_event_queue = {}
+        self._kernel_name_to_wait_event_queue: Dict[str, List[Any]] = {}
 
         if queue.device.type & cl.device_type.GPU:
             if allocator is None:
@@ -110,7 +125,7 @@ class PyOpenCLArrayContext(ArrayContext):
                         "are running Python in debug mode. Use 'python -O' for "
                         "a noticeable speed improvement.")
 
-        self._loopy_transform_cache = {}
+        self._loopy_transform_cache: dict = {}
 
     def _get_fake_numpy_namespace(self):
         from arraycontext.impl.pyopencl.fake_numpy import PyOpenCLFakeNumpyNamespace
@@ -133,6 +148,10 @@ class PyOpenCLArrayContext(ArrayContext):
         return cl_array.to_device(self.queue, array, allocator=self.allocator)
 
     def to_numpy(self, array):
+        from numbers import Number
+        if not self._force_device_scalars and isinstance(array, Number):
+            return array
+
         return array.get(queue=self.queue)
 
     def call_loopy(self, t_unit, **kwargs):
@@ -229,7 +248,9 @@ class PyOpenCLArrayContext(ArrayContext):
         return array
 
     def clone(self):
-        return type(self)(self.queue, self.allocator, self._wait_event_queue_length)
+        return type(self)(self.queue, self.allocator,
+                wait_event_queue_length=self._wait_event_queue_length,
+                force_device_scalars=self._force_device_scalars)
 
     @property
     def permits_inplace_modification(self):

--- a/arraycontext/impl/pyopencl/__init__.py
+++ b/arraycontext/impl/pyopencl/__init__.py
@@ -40,6 +40,7 @@ from arraycontext.context import ArrayContext
 
 if TYPE_CHECKING:
     import pyopencl
+    import loopy as lp
 
 
 # {{{ PyOpenCLArrayContext
@@ -131,7 +132,8 @@ class PyOpenCLArrayContext(ArrayContext):
                         "are running Python in debug mode. Use 'python -O' for "
                         "a noticeable speed improvement.")
 
-        self._loopy_transform_cache: dict = {}
+        self._loopy_transform_cache: \
+                Dict[lp.TranslationUnit, lp.TranslationUnit] = {}
 
     def _get_fake_numpy_namespace(self):
         from arraycontext.impl.pyopencl.fake_numpy import PyOpenCLFakeNumpyNamespace

--- a/arraycontext/impl/pyopencl/__init__.py
+++ b/arraycontext/impl/pyopencl/__init__.py
@@ -92,6 +92,12 @@ class PyOpenCLArrayContext(ArrayContext):
 
             For now, *wait_event_queue_length* should be regarded as an
             experimental feature that may change or disappear at any minute.
+
+        :arg force_device_scalars: if *True*, scalar results returned from
+            reductions in :attr:`ArrayContext.np` will be kept on the device.
+            If *False*, the equivalent of :meth:`~ArrayContext.freeze` and
+            :meth:`~ArrayContext.to_numpy` is applied to transfer the results
+            to the host.
         """
         if not force_device_scalars:
             warn("Returning host scalars from the array context is deprecated. "

--- a/arraycontext/pytest.py
+++ b/arraycontext/pytest.py
@@ -1,8 +1,9 @@
 """
 .. currentmodule:: arraycontext
+
+.. autofunction:: pytest_generate_tests_for_array_context
 .. autofunction:: pytest_generate_tests_for_pyopencl_array_context
 """
-
 
 __copyright__ = """
 Copyright (C) 2020-1 University of Illinois Board of Trustees
@@ -28,48 +29,96 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from typing import Optional, Sequence
+
+import pyopencl as cl
+from pyopencl.tools import _ContextFactory
+
+
+# {{{ array context factories
+
+class _PyOpenCLArrayContextFactory(_ContextFactory):
+    force_device_scalars = True
+
+    def __call__(self):
+        ctx = super().__call__()
+        from arraycontext.impl.pyopencl import PyOpenCLArrayContext
+        return PyOpenCLArrayContext(
+                cl.CommandQueue(ctx),
+                force_device_scalars=self.force_device_scalars)
+
+    def __str__(self):
+        return ("<array context factory for <pyopencl.Device '%s' on '%s'>" %
+                (self.device.name.strip(),
+                 self.device.platform.name.strip()))
+
+
+class _DeprecatedPyOpenCLArrayContextFactory(_PyOpenCLArrayContextFactory):
+    force_device_scalars = False
+
+
+_ARRAY_CONTEXT_FACTORY_DICT = {
+        "pyopencl": _PyOpenCLArrayContextFactory,
+        }
+_ALL_ARRAY_CONTEXT_FACTORY_DICT = {
+        "pyopencl-deprecated": _DeprecatedPyOpenCLArrayContextFactory,
+        }
+
+_ALL_ARRAY_CONTEXT_FACTORY_DICT.update(_ARRAY_CONTEXT_FACTORY_DICT)
+
+# }}}
+
 
 # {{{ pytest integration
 
-def pytest_generate_tests_for_pyopencl_array_context(metafunc):
-    """Parametrize tests for pytest to use a
-    :class:`~arraycontext.PyOpenCLArrayContext`.
+def pytest_generate_tests_for_array_context(
+        metafunc,
+        impls: Optional[Sequence[str]] = None):
+    """Parametrize tests for pytest to use an :class:`~arraycontext.ArrayContext`.
 
-    Performs device enumeration analogously to
-    :func:`pyopencl.tools.pytest_generate_tests_for_pyopencl`.
-
-    Using the line:
+    Using the line
 
     .. code-block:: python
 
-       from arraycontext import pytest_generate_tests_for_pyopencl
-            as pytest_generate_tests
+       from arraycontext import (
+            pytest_generate_tests_for_array_context
+            as pytest_generate_tests)
 
     in your pytest test scripts allows you to use the argument ``actx_factory``,
-    in your test functions, and they will automatically be
-    run once for each OpenCL device/platform in the system, as appropriate,
-    with an argument-less function that returns an
-    :class:`~arraycontext.ArrayContext` when called.
+    which is a callable that returns a :class:`~arraycontext.ArrayContext`.
+    All test functions will automaticall be run once for each implemented array
+    context. To select specific array context implementations explicitly
+    define, for example,
 
-    It also allows you to specify the ``PYOPENCL_TEST`` environment variable
-    for device selection.
+    .. code-block:: python
+
+        def pytest_generate_tests(metafunc):
+            pytest_generate_tests_for_array_context(metafunc, impls=["pyopencl"])
+
+    to use the :mod:`pyopencl`-based array context. For :mod:`pyopencl`-based
+    contexts :func:`pyopencl.tools.pytest_generate_tests_for_pyopencl` is used
+    as a backend, which allows specifying the ``PYOPENCL_TEST`` environment
+    variable for device selection.
+
+    Current supported implementations include:
+
+    * ``"pyopencl"``, which creates a :class:`~arraycontext.PyOpenCLArrayContext`
+      with ``force_device_scalars=True``.
+    * ``"pyopencl-deprecated"``, which creates a
+      :class:`~arraycontext.PyOpenCLArrayContext` with
+      ``force_device_scalars=False``.
+
+    :arg impls: a list of identifiers for desired implementations.
     """
 
-    import pyopencl as cl
-    from pyopencl.tools import _ContextFactory
-
-    class ArrayContextFactory(_ContextFactory):
-        def __call__(self, force_device_scalars=False):
-            ctx = super().__call__()
-            from arraycontext.impl.pyopencl import PyOpenCLArrayContext
-            return PyOpenCLArrayContext(
-                    cl.CommandQueue(ctx),
-                    force_device_scalars=force_device_scalars)
-
-        def __str__(self):
-            return ("<array context factory for <pyopencl.Device '%s' on '%s'>" %
-                    (self.device.name.strip(),
-                     self.device.platform.name.strip()))
+    if impls is None:
+        impls = list(_ARRAY_CONTEXT_FACTORY_DICT.values())
+    else:
+        unknown_impls = [
+                impl for impl in impls
+                if impl not in _ALL_ARRAY_CONTEXT_FACTORY_DICT]
+        if unknown_impls:
+            raise ValueError(f"unknown array contexts: {unknown_impls}")
 
     import pyopencl.tools as cl_tools
     arg_names = cl_tools.get_pyopencl_fixture_arg_names(
@@ -84,15 +133,50 @@ def pytest_generate_tests_for_pyopencl_array_context(metafunc):
             raise RuntimeError("Cannot use both an 'actx_factory' and a "
                     "'ctx_factory' / 'ctx_getter' as arguments.")
 
+        arg_values_with_actx = []
         for arg_dict in arg_values:
-            arg_dict["actx_factory"] = ArrayContextFactory(arg_dict["device"])
+            for impl in impls:
+                arg = arg_dict.copy()
+                arg["actx_factory"] = \
+                        _ALL_ARRAY_CONTEXT_FACTORY_DICT[impl](arg_dict["device"])
 
-    arg_values = [
+                arg_values_with_actx.append(arg)
+    else:
+        arg_values_with_actx = arg_values
+
+    arg_value_tuples = [
             tuple(arg_dict[name] for name in arg_names)
-            for arg_dict in arg_values
+            for arg_dict in arg_values_with_actx
             ]
 
-    metafunc.parametrize(arg_names, arg_values, ids=ids)
+    metafunc.parametrize(arg_names, arg_value_tuples, ids=ids)
+
+
+def pytest_generate_tests_for_pyopencl_array_context(metafunc):
+    """Parametrize tests for pytest to use a
+    :class:`~arraycontext.PyOpenCLArrayContext`.
+
+    Performs device enumeration analogously to
+    :func:`pyopencl.tools.pytest_generate_tests_for_pyopencl`.
+
+    Using the line:
+
+    .. code-block:: python
+
+       from arraycontext import (
+            pytest_generate_tests_for_pyopencl_array_context
+            as pytest_generate_tests)
+
+    in your pytest test scripts allows you to use the argument ``actx_factory``,
+    in your test functions, and they will automatically be
+    run once for each OpenCL device/platform in the system, as appropriate,
+    with an argument-less function that returns an
+    :class:`~arraycontext.ArrayContext` when called.
+
+    It also allows you to specify the ``PYOPENCL_TEST`` environment variable
+    for device selection.
+    """
+    pytest_generate_tests_for_array_context(metafunc, impls=["pyopencl-deprecated"])
 
 # }}}
 

--- a/arraycontext/pytest.py
+++ b/arraycontext/pytest.py
@@ -120,10 +120,10 @@ def pytest_generate_tests_for_array_context(
     env_impls_string = os.environ.get("ARRAYCONTEXT_TEST", None)
 
     if env_impls_string is not None:
-        impls = set(env_impls_string.split(","))
+        unique_impls = set(env_impls_string.split(","))
 
         unknown_impls = [
-                impl for impl in impls
+                impl for impl in unique_impls
                 if impl not in _ALL_ARRAY_CONTEXT_FACTORY_DICT]
         if unknown_impls:
             raise RuntimeError(
@@ -131,14 +131,18 @@ def pytest_generate_tests_for_array_context(
                     f"variable 'ARRAYCONTEXT_TEST': {unknown_impls}")
     else:
         if impls is None:
-            impls = set(_ARRAY_CONTEXT_FACTORY_DICT.values())
+            unique_impls = set(
+                    _ARRAY_CONTEXT_FACTORY_DICT.values())  # type: ignore[arg-type]
         else:
-            impls = set(impls)
+            unique_impls = set(impls)
             unknown_impls = [
-                    impl for impl in impls
+                    impl for impl in unique_impls
                     if impl not in _ALL_ARRAY_CONTEXT_FACTORY_DICT]
             if unknown_impls:
                 raise ValueError(f"unknown array contexts: {unknown_impls}")
+
+    if not unique_impls:
+        raise ValueError("no array contexts were selected")
 
     # }}}
 
@@ -164,7 +168,7 @@ def pytest_generate_tests_for_array_context(
 
         arg_values_with_actx = []
         for arg_dict in arg_values:
-            for impl in impls:
+            for impl in unique_impls:
                 arg = arg_dict.copy()
                 arg["actx_factory"] = \
                         _ALL_ARRAY_CONTEXT_FACTORY_DICT[impl](arg_dict["device"])

--- a/arraycontext/pytest.py
+++ b/arraycontext/pytest.py
@@ -95,6 +95,16 @@ _ALL_ARRAY_CONTEXT_FACTORY_DICT: Dict[str, Type[PytestArrayContextFactory]] = {
         }
 _ALL_ARRAY_CONTEXT_FACTORY_DICT.update(_ARRAY_CONTEXT_FACTORY_DICT)
 
+
+def register_array_context_factory(
+        name: str,
+        factory: Type[PytestArrayContextFactory]) -> None:
+    if name in _ALL_ARRAY_CONTEXT_FACTORY_DICT:
+        raise ValueError(f"factory '{name}' already exists")
+
+    _ARRAY_CONTEXT_FACTORY_DICT[name] = factory
+    _ALL_ARRAY_CONTEXT_FACTORY_DICT[name] = factory
+
 # }}}
 
 

--- a/arraycontext/pytest.py
+++ b/arraycontext/pytest.py
@@ -59,10 +59,12 @@ def pytest_generate_tests_for_pyopencl_array_context(metafunc):
     from pyopencl.tools import _ContextFactory
 
     class ArrayContextFactory(_ContextFactory):
-        def __call__(self):
+        def __call__(self, force_device_scalars=False):
             ctx = super().__call__()
             from arraycontext.impl.pyopencl import PyOpenCLArrayContext
-            return PyOpenCLArrayContext(cl.CommandQueue(ctx))
+            return PyOpenCLArrayContext(
+                    cl.CommandQueue(ctx),
+                    force_device_scalars=force_device_scalars)
 
         def __str__(self):
             return ("<array context factory for <pyopencl.Device '%s' on '%s'>" %

--- a/run-mypy.sh
+++ b/run-mypy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python -m mypy arraycontext/ examples/ test/
+python -m mypy --show-error-codes arraycontext examples test

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -33,17 +33,16 @@ from arraycontext import (
         freeze, thaw,
         FirstAxisIsElementsTag)
 from arraycontext import (  # noqa: F401
-        pytest_generate_tests_for_array_context,
+        pytest_generate_tests_for_array_contexts,
         _acf)
 
 import logging
 logger = logging.getLogger(__name__)
 
 
-def pytest_generate_tests(metafunc):
-    pytest_generate_tests_for_array_context(metafunc, impls=[
-        "pyopencl", "pyopencl-deprecated",
-        ])
+pytest_generate_tests = pytest_generate_tests_for_array_contexts([
+    "pyopencl", "pyopencl-deprecated",
+    ])
 
 
 # {{{ stand-in DOFArray implementation

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -398,8 +398,12 @@ def test_dof_array_reductions_same_as_numpy(actx_factory):
         np_red = getattr(np, name)(ary)
         actx_red = getattr(actx.np, name)(actx.from_numpy(ary))
 
-        assert isinstance(actx_red, Number)
-        assert np.allclose(np_red, actx_red)
+        if actx._force_device_scalars:
+            assert actx_red.shape == ()
+        else:
+            assert isinstance(actx_red, Number)
+
+        assert np.allclose(np_red, actx.to_numpy(actx_red))
 
 # }}}
 
@@ -727,7 +731,7 @@ def test_norm_ord_none(actx_factory, ndim):
     norm_a_ref = np.linalg.norm(a, ord=None)
     norm_a = actx.np.linalg.norm(actx.from_numpy(a), ord=None)
 
-    np.testing.assert_allclose(norm_a, norm_a_ref)
+    np.testing.assert_allclose(actx.to_numpy(norm_a), norm_a_ref)
 
 
 if __name__ == "__main__":

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -180,8 +180,10 @@ def assert_close_to_numpy_in_containers(actx, op, args):
             ("where", 3),
             ("conj", 1),
             ])
-def test_array_context_np_workalike(actx_factory, sym_name, n_args):
-    actx = actx_factory()
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_array_context_np_workalike(actx_factory, sym_name, n_args,
+        force_device_scalars):
+    actx = actx_factory(force_device_scalars)
 
     ndofs = 5000
     args = [np.random.randn(ndofs) for i in range(n_args)]
@@ -194,8 +196,9 @@ def test_array_context_np_workalike(actx_factory, sym_name, n_args):
             ("zeros_like", 1),
             ("ones_like", 1),
             ])
-def test_array_context_np_like(actx_factory, sym_name, n_args):
-    actx = actx_factory()
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_array_context_np_like(actx_factory, sym_name, n_args, force_device_scalars):
+    actx = actx_factory(force_device_scalars)
 
     ndofs = 5000
     args = [np.random.randn(ndofs) for i in range(n_args)]
@@ -207,8 +210,9 @@ def test_array_context_np_like(actx_factory, sym_name, n_args):
 
 # {{{ array manipulations
 
-def test_actx_stack(actx_factory):
-    actx = actx_factory()
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_actx_stack(actx_factory, force_device_scalars):
+    actx = actx_factory(force_device_scalars)
 
     ndofs = 5000
     args = [np.random.randn(ndofs) for i in range(10)]
@@ -217,8 +221,9 @@ def test_actx_stack(actx_factory):
             actx, lambda _np, *_args: _np.stack(_args), args)
 
 
-def test_actx_concatenate(actx_factory):
-    actx = actx_factory()
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_actx_concatenate(actx_factory, force_device_scalars):
+    actx = actx_factory(force_device_scalars)
 
     ndofs = 5000
     args = [np.random.randn(ndofs) for i in range(10)]
@@ -227,8 +232,9 @@ def test_actx_concatenate(actx_factory):
             actx, lambda _np, *_args: _np.concatenate(_args), args)
 
 
-def test_actx_reshape(actx_factory):
-    actx = actx_factory()
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_actx_reshape(actx_factory, force_device_scalars):
+    actx = actx_factory(force_device_scalars)
 
     for new_shape in [(3, 2), (3, -1), (6,), (-1,)]:
         assert_close_to_numpy(
@@ -236,9 +242,10 @@ def test_actx_reshape(actx_factory):
                 (np.random.randn(2, 3), new_shape))
 
 
-def test_actx_ravel(actx_factory):
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_actx_ravel(actx_factory, force_device_scalars):
     from numpy.random import default_rng
-    actx = actx_factory()
+    actx = actx_factory(force_device_scalars)
     rng = default_rng()
     ndim = rng.integers(low=1, high=6)
     shape = tuple(rng.integers(2, 7, ndim))
@@ -251,8 +258,9 @@ def test_actx_ravel(actx_factory):
 
 # {{{ arithmetic same as numpy
 
-def test_dof_array_arithmetic_same_as_numpy(actx_factory):
-    actx = actx_factory()
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_dof_array_arithmetic_same_as_numpy(actx_factory, force_device_scalars):
+    actx = actx_factory(force_device_scalars)
 
     ndofs = 50_000
 
@@ -389,8 +397,9 @@ def test_dof_array_arithmetic_same_as_numpy(actx_factory):
 
 # {{{ reductions same as numpy
 
-def test_dof_array_reductions_same_as_numpy(actx_factory):
-    actx = actx_factory()
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_dof_array_reductions_same_as_numpy(actx_factory, force_device_scalars):
+    actx = actx_factory(force_device_scalars)
 
     from numbers import Number
     for name in ["sum", "min", "max"]:
@@ -415,8 +424,10 @@ def test_dof_array_reductions_same_as_numpy(actx_factory):
     "ij->ji",
     "ii->i",
 ])
-def test_array_context_einsum_array_manipulation(actx_factory, spec):
-    actx = actx_factory()
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_array_context_einsum_array_manipulation(actx_factory, spec,
+        force_device_scalars):
+    actx = actx_factory(force_device_scalars)
 
     mat = actx.from_numpy(np.random.randn(10, 10))
     res = actx.to_numpy(actx.einsum(spec, mat,
@@ -430,8 +441,10 @@ def test_array_context_einsum_array_manipulation(actx_factory, spec):
     "ij,ji->ij",
     "ij,kj->ik",
 ])
-def test_array_context_einsum_array_matmatprods(actx_factory, spec):
-    actx = actx_factory()
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_array_context_einsum_array_matmatprods(actx_factory, spec,
+        force_device_scalars):
+    actx = actx_factory(force_device_scalars)
 
     mat_a = actx.from_numpy(np.random.randn(5, 5))
     mat_b = actx.from_numpy(np.random.randn(5, 5))
@@ -444,8 +457,10 @@ def test_array_context_einsum_array_matmatprods(actx_factory, spec):
 @pytest.mark.parametrize("spec", [
     "im,mj,k->ijk"
 ])
-def test_array_context_einsum_array_tripleprod(actx_factory, spec):
-    actx = actx_factory()
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_array_context_einsum_array_tripleprod(actx_factory, spec,
+        force_device_scalars):
+    actx = actx_factory(force_device_scalars)
 
     mat_a = actx.from_numpy(np.random.randn(7, 5))
     mat_b = actx.from_numpy(np.random.randn(5, 7))
@@ -522,8 +537,9 @@ def _get_test_containers(actx, ambient_dim=2):
             bcast_dataclass_of_dofs)
 
 
-def test_container_multimap(actx_factory):
-    actx = actx_factory()
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_container_multimap(actx_factory, force_device_scalars):
+    actx = actx_factory(force_device_scalars)
     ary_dof, ary_of_dofs, mat_of_dofs, dc_of_dofs, bcast_dc_of_dofs = \
             _get_test_containers(actx)
 
@@ -563,8 +579,9 @@ def test_container_multimap(actx_factory):
     # }}}
 
 
-def test_container_arithmetic(actx_factory):
-    actx = actx_factory()
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_container_arithmetic(actx_factory, force_device_scalars):
+    actx = actx_factory(force_device_scalars)
     ary_dof, ary_of_dofs, mat_of_dofs, dc_of_dofs, bcast_dc_of_dofs = \
             _get_test_containers(actx)
 
@@ -614,8 +631,9 @@ def test_container_arithmetic(actx_factory):
     # }}}
 
 
-def test_container_freeze_thaw(actx_factory):
-    actx = actx_factory()
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_container_freeze_thaw(actx_factory, force_device_scalars):
+    actx = actx_factory(force_device_scalars)
     ary_dof, ary_of_dofs, mat_of_dofs, dc_of_dofs, bcast_dc_of_dofs = \
             _get_test_containers(actx)
 
@@ -657,8 +675,9 @@ def test_container_freeze_thaw(actx_factory):
 
 
 @pytest.mark.parametrize("ord", [2, np.inf])
-def test_container_norm(actx_factory, ord):
-    actx = actx_factory()
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_container_norm(actx_factory, ord, force_device_scalars):
+    actx = actx_factory(force_device_scalars)
 
     ary_dof, ary_of_dofs, mat_of_dofs, dc_of_dofs, bcast_dc_of_dofs = \
             _get_test_containers(actx)
@@ -675,8 +694,9 @@ def test_container_norm(actx_factory, ord):
 
 # {{{ test from_numpy and to_numpy
 
-def test_numpy_conversion(actx_factory):
-    actx = actx_factory()
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_numpy_conversion(actx_factory, force_device_scalars):
+    actx = actx_factory(force_device_scalars)
 
     ac = MyContainer(
             name="test_numpy_conversion",
@@ -707,8 +727,9 @@ def test_numpy_conversion(actx_factory):
 
 
 @pytest.mark.parametrize("norm_ord", [2, np.inf])
-def test_norm_complex(actx_factory, norm_ord):
-    actx = actx_factory()
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_norm_complex(actx_factory, norm_ord, force_device_scalars):
+    actx = actx_factory(force_device_scalars)
     a = np.random.randn(2000) + 1j * np.random.randn(2000)
 
     norm_a_ref = np.linalg.norm(a, norm_ord)
@@ -718,10 +739,11 @@ def test_norm_complex(actx_factory, norm_ord):
 
 
 @pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])
-def test_norm_ord_none(actx_factory, ndim):
-    from numpy.random import default_rng
+@pytest.mark.parametrize("force_device_scalars", [True, False])
+def test_norm_ord_none(actx_factory, ndim, force_device_scalars):
+    actx = actx_factory(force_device_scalars)
 
-    actx = actx_factory()
+    from numpy.random import default_rng
 
     rng = default_rng()
     shape = tuple(rng.integers(2, 7, ndim))


### PR DESCRIPTION
This is built on top of #43, so it has a few annoying commits in there (see alexfikl/arraycontext#1 for a nicer full diff). Only a305c3c and 32be014 should be in here.

It adds a `pytest_generate_tests_for_array_context` that takes an `impls` argument, similar to what was proposed in #14. It should be easy to add other array contexts as well, so hopefully it can be used for the lazy one too.