### PR TITLE
Make broadcast settings visible on users of with_container_arithmetic

### DIFF
--- a/arraycontext/container/arithmetic.py
+++ b/arraycontext/container/arithmetic.py
@@ -280,7 +280,7 @@ def with_container_arithmetic(
             else:
                 return "(%s,)" % ", ".join(t)
 
-        gen(f"cls._outer_bcast_names = {tup_str(outer_bcast_type_names)}")
+        gen(f"cls._outer_bcast_types = {tup_str(outer_bcast_type_names)}")
         gen(f"cls._bcast_numpy_array = {bcast_numpy_array}")
         gen(f"cls._bcast_obj_array = {bcast_obj_array}")
         gen("")

--- a/arraycontext/container/arithmetic.py
+++ b/arraycontext/container/arithmetic.py
@@ -394,7 +394,6 @@ def with_container_arithmetic(
 
         # }}}
 
-        print(gen.get())
         # This will evaluate the module, which is all we need.
         code = gen.get().rstrip()+"\n"
         result_dict = {"_MODULE_SOURCE_CODE": code, "cls": cls}

--- a/arraycontext/container/arithmetic.py
+++ b/arraycontext/container/arithmetic.py
@@ -280,6 +280,10 @@ def with_container_arithmetic(
             else:
                 return "(%s,)" % ", ".join(t)
 
+        gen(f"cls._outer_bcast_names = {tup_str(outer_bcast_type_names)}")
+        gen(f"cls._bcast_numpy_array = {bcast_numpy_array}")
+        gen(f"cls._bcast_obj_array = {bcast_obj_array}")
+        gen("")
         # {{{ unary operators
 
         for dunder_name, op_str, op_cls in _UNARY_OP_AND_DUNDER:
@@ -390,6 +394,7 @@ def with_container_arithmetic(
 
         # }}}
 
+        print(gen.get())
         # This will evaluate the module, which is all we need.
         code = gen.get().rstrip()+"\n"
         result_dict = {"_MODULE_SOURCE_CODE": code, "cls": cls}


### PR DESCRIPTION
This is to support use cases like https://github.com/illinois-ceesd/mirgecom/pull/331, where the information that `with_container_arithmetic` has about the desired broadcast behavior of a type would also be useful to have. To make it available, this just shoves it into some (undocumented, for now) class attributes. In the linked use case, this would help (e.g.) avoid the need for hardcoding `DOFArray`. Instead, it could check whether `np.ndarray` is in `type(obj)._outer_bcast_names` and then follow that behavior.

I also have a distinct feeling that this might also be a bad idea. @alexfikl, got a gut feeling on this one?

cc @majosm