### PR TITLE
Fix management of CL context lifetimes in pytest fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,29 @@ jobs:
         -   uses: actions/checkout@v2
         -   name: "Main Script"
             run: |
-                export MPLBACKEND=Agg
                 curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/ci-support.sh
                 . ./ci-support.sh
+                build_py_project_in_conda_env
+                test_py_project
+
+    pytest3_intel_cl:
+        name: Pytest Conda Py3
+        runs-on: ubuntu-latest
+        steps:
+        -   uses: actions/checkout@v2
+        -   name: "Main Script"
+            run: |
+                curl -L -O https://raw.githubusercontent.com/illinois-scicomp/machine-shop-maintenance/main/install-intel-icd.sh
+                sudo bash ./install-intel-icd.sh
+
+                CONDA_ENVIRONMENT=.test-conda-env-py3.yml
+                echo "- ocl-icd-system" >> "$CONDA_ENVIRONMENT"
+                sed -i "/pocl/ d" "$CONDA_ENVIRONMENT"
+                export PYOPENCL_TEST=intel
+                source /opt/enable-intel-cl.sh
+
+                curl -L -O https://tiker.net/ci-support-v0
+                . ./ci-support-v0
                 build_py_project_in_conda_env
                 test_py_project
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
                 python -m pip install mypy
                 ./run-mypy.sh
 
-    pytest3:
-        name: Pytest Conda Py3
+    pytest3_pocl:
+        name: Pytest Conda Py3 POCL
         runs-on: ubuntu-latest
         steps:
         -   uses: actions/checkout@v2
@@ -64,7 +64,7 @@ jobs:
                 test_py_project
 
     pytest3_intel_cl:
-        name: Pytest Conda Py3
+        name: Pytest Conda Py3 Intel
         runs-on: ubuntu-latest
         steps:
         -   uses: actions/checkout@v2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,8 +38,7 @@ Python 3 POCL Examples:
   - test -n "$SKIP_EXAMPLES" && exit
   - export PY_EXE=python3
   - export PYOPENCL_TEST=portable:pthread
-  # cython is here because pytential (for now, for TS) depends on it
-  - export EXTRA_INSTALL="pybind11 cython numpy mako matplotlib"
+  - export EXTRA_INSTALL="pybind11 numpy mako"
   - curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/build-py-project-and-run-examples.sh
   - ". ./build-py-project-and-run-examples.sh"
   tags:
@@ -51,7 +50,6 @@ Python 3 POCL Examples:
 
 Python 3 Conda:
   script: |
-    export MPLBACKEND=Agg
     curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/build-and-test-py-project-within-miniconda.sh
     . ./build-and-test-py-project-within-miniconda.sh
   tags:
@@ -82,7 +80,7 @@ Flake8:
 Pylint:
   script: |
     export PY_EXE=python3
-    EXTRA_INSTALL="Cython pybind11 numpy mako matplotlib scipy mpi4py oct2py"
+    EXTRA_INSTALL="pybind11 numpy mako"
     curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/master/prepare-and-run-pylint.sh
     . ./prepare-and-run-pylint.sh "$CI_PROJECT_NAME" examples/*.py test/test_*.py
   tags:


### PR DESCRIPTION
Addresses CI failures such as this one: https://gitlab.tiker.net/inducer/grudge/-/jobs/287098