### PR TITLE
Deprecate transform knowledge

### DIFF
--- a/arraycontext/__init__.py
+++ b/arraycontext/__init__.py
@@ -28,9 +28,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import sys
 from .context import ArrayContext
 
-from .metadata import CommonSubexpressionTag, FirstAxisIsElementsTag
+from .transform_metadata import (CommonSubexpressionTag,
+        ElementwiseMapKernelTag)
+
+# deprecated, remove in 2022.
+from .metadata import _FirstAxisIsElementsTag
 
 from .container import (
         ArrayContainer,
@@ -64,7 +69,7 @@ __all__ = (
         "ArrayContext",
 
         "CommonSubexpressionTag",
-        "FirstAxisIsElementsTag",
+        "ElementwiseMapKernelTag",
 
         "ArrayContainer",
         "is_array_container", "is_array_container_type",
@@ -90,7 +95,9 @@ __all__ = (
         )
 
 
-def _acf():
+# {{{ deprecation handling
+
+def _deprecated_acf():
     """A tiny undocumented function to pass to tests that take an ``actx_factory``
     argument when running them from the command line.
     """
@@ -99,5 +106,33 @@ def _acf():
     context = cl._csc()
     queue = cl.CommandQueue(context)
     return PyOpenCLArrayContext(queue)
+
+
+_depr_name_to_replacement_and_obj = {
+        "FirstAxisIsElementsTag":
+        ("meshmode.transform_metadata.FirstAxisIsElementsTag",
+            _FirstAxisIsElementsTag),
+        "_acf":
+        ("<no replacement yet>", _deprecated_acf),
+        }
+
+if sys.version_info >= (3, 7):
+    def __getattr__(name):
+        replacement_and_obj = _depr_name_to_replacement_and_obj.get(name, None)
+        if replacement_and_obj is not None:
+            replacement, obj = replacement_and_obj
+            from warnings import warn
+            warn(f"'arraycontext.{name}' is deprecated. "
+                    f"Use '{replacement}' instead. "
+                    f"'arraycontext.{name}' will continue to work until 2022.",
+                    DeprecationWarning, stacklevel=2)
+            return obj
+        else:
+            raise AttributeError(name)
+else:
+    FirstAxisIsElementsTag = _FirstAxisIsElementsTag
+    _acf = _deprecated_acf
+
+# }}}
 
 # vim: foldmethod=marker

--- a/arraycontext/context.py
+++ b/arraycontext/context.py
@@ -218,6 +218,7 @@ class ArrayContext(ABC):
 
         import loopy as lp
         from .loopy import make_loopy_program
+        from arraycontext.transform_metadata import ElementwiseMapKernelTag
         return make_loopy_program(
                 [domain_bset],
                 [
@@ -226,7 +227,8 @@ class ArrayContext(ABC):
                         var(c_name)(*[
                             var("inp%d" % i)[subscript] for i in range(nargs)]))
                     ],
-                name="actx_special_%s" % c_name)
+                name="actx_special_%s" % c_name,
+                tags=(ElementwiseMapKernelTag(),))
 
     @abstractmethod
     def freeze(self, array):

--- a/arraycontext/impl/pyopencl/__init__.py
+++ b/arraycontext/impl/pyopencl/__init__.py
@@ -34,7 +34,6 @@ import numpy as np
 
 from pytools.tag import Tag
 
-from arraycontext.metadata import FirstAxisIsElementsTag
 from arraycontext.context import ArrayContext
 
 
@@ -223,9 +222,13 @@ class PyOpenCLArrayContext(ArrayContext):
         all_inames = default_entrypoint.all_inames()
         # FIXME: This could be much smarter.
         inner_iname = None
+
+        # import with underscore to avoid DeprecationWarning
+        from arraycontext.metadata import _FirstAxisIsElementsTag
+
         if (len(default_entrypoint.instructions) == 1
                 and isinstance(default_entrypoint.instructions[0], lp.Assignment)
-                and any(isinstance(tag, FirstAxisIsElementsTag)
+                and any(isinstance(tag, _FirstAxisIsElementsTag)
                     # FIXME: Firedrake branch lacks kernel tags
                     for tag in getattr(default_entrypoint, "tags", ()))):
             stmt, = default_entrypoint.instructions

--- a/arraycontext/impl/pyopencl/__init__.py
+++ b/arraycontext/impl/pyopencl/__init__.py
@@ -101,8 +101,11 @@ class PyOpenCLArrayContext(ArrayContext):
             to the host.
         """
         if not force_device_scalars:
-            warn("Returning host scalars from the array context is deprecated. "
-                    "To return device scalars set 'force_device_scalars=True'. "
+            warn("Configuring the PyOpenCLArrayContext to return host scalars "
+                    "from reductions is deprecated. "
+                    "To configure the PyOpenCLArrayContext to return "
+                    "device scalars, pass 'force_device_scalars=True' to the "
+                    "constructor. "
                     "Support for returning host scalars will be removed in 2022.",
                     DeprecationWarning, stacklevel=2)
 

--- a/arraycontext/impl/pyopencl/__init__.py
+++ b/arraycontext/impl/pyopencl/__init__.py
@@ -199,6 +199,16 @@ class PyOpenCLArrayContext(ArrayContext):
             pass
         orig_t_unit = t_unit
 
+        from warnings import warn
+        warn("Using arraycontext.PyOpenCLArrayContext.transform_loopy_program "
+                "to transform a program. This is deprecated and will stop working "
+                "in 2022. Instead, subclass PyOpenCLArrayContext and implement "
+                "the specific logic required to transform the program for your "
+                "package or application. Check higher-level packages "
+                "(e.g. meshmode), which may already have subclasses you may want "
+                "to build on.",
+                DeprecationWarning, stacklevel=2)
+
         # accommodate loopy with and without kernel callables
 
         import loopy as lp

--- a/arraycontext/impl/pyopencl/__init__.py
+++ b/arraycontext/impl/pyopencl/__init__.py
@@ -167,7 +167,10 @@ class PyOpenCLArrayContext(ArrayContext):
         try:
             t_unit = self._loopy_transform_cache[t_unit]
         except KeyError:
+            orig_t_unit = t_unit
             t_unit = self.transform_loopy_program(t_unit)
+            self._loopy_transform_cache[orig_t_unit] = t_unit
+            del orig_t_unit
 
         evt, result = t_unit(self.queue, **kwargs, allocator=self.allocator)
 
@@ -192,12 +195,6 @@ class PyOpenCLArrayContext(ArrayContext):
     # }}}
 
     def transform_loopy_program(self, t_unit):
-        try:
-            return self._loopy_transform_cache[t_unit]
-        except KeyError:
-            pass
-        orig_t_unit = t_unit
-
         from warnings import warn
         warn("Using arraycontext.PyOpenCLArrayContext.transform_loopy_program "
                 "to transform a program. This is deprecated and will stop working "
@@ -259,7 +256,6 @@ class PyOpenCLArrayContext(ArrayContext):
             t_unit = lp.split_iname(t_unit, inner_iname, 16, inner_tag="l.0")
         t_unit = lp.tag_inames(t_unit, {outer_iname: "g.0"})
 
-        self._loopy_transform_cache[orig_t_unit] = t_unit
         return t_unit
 
     def tag(self, tags: Union[Sequence[Tag], Tag], array):

--- a/arraycontext/loopy.py
+++ b/arraycontext/loopy.py
@@ -39,7 +39,7 @@ _DEFAULT_LOOPY_OPTIONS = lp.Options(
 
 
 def make_loopy_program(domains, statements, kernel_data=None,
-        name="mm_actx_kernel"):
+        name="mm_actx_kernel", tags=None):
     """Return a :class:`loopy.LoopKernel` suitable for use with
     :meth:`ArrayContext.call_loopy`.
     """
@@ -53,7 +53,8 @@ def make_loopy_program(domains, statements, kernel_data=None,
             options=_DEFAULT_LOOPY_OPTIONS,
             default_offset=lp.auto,
             name=name,
-            lang_version=MOST_RECENT_LANGUAGE_VERSION)
+            lang_version=MOST_RECENT_LANGUAGE_VERSION,
+            tags=tags)
 
 
 def get_default_entrypoint(t_unit):

--- a/arraycontext/pytest.py
+++ b/arraycontext/pytest.py
@@ -257,6 +257,15 @@ def pytest_generate_tests_for_pyopencl_array_context(metafunc) -> None:
     for device selection.
     """
 
+    from warnings import warn
+    warn("pytest_generate_tests_for_pyopencl_array_context is deprecated. "
+            "Use 'pytest_generate_tests = "
+            "arraycontext.pytest_generate_tests_for_array_contexts"
+            "([\"pyopencl-deprecated\"])' instead. "
+            "pytest_generate_tests_for_pyopencl_array_context will stop working "
+            "in 2022.",
+            DeprecationWarning, stacklevel=2)
+
     pytest_generate_tests_for_array_contexts([
         "pyopencl-deprecated",
         ], factory_arg_name="actx_factory")(metafunc)

--- a/arraycontext/transform_metadata.py
+++ b/arraycontext/transform_metadata.py
@@ -1,3 +1,10 @@
+"""
+.. currentmodule:: arraycontext
+
+.. autoclass:: CommonSubexpressionTag
+.. autoclass:: ElementwiseMapKernelTag
+"""
+
 __copyright__ = """
 Copyright (C) 2020-1 University of Illinois Board of Trustees
 """
@@ -22,34 +29,29 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import sys
 from pytools.tag import Tag
-from warnings import warn
 
 
-# {{{ deprecation handling
+# {{{ program metadata
 
-try:
-    from meshmode.transform_metadata import FirstAxisIsElementsTag \
-            as _FirstAxisIsElementsTag
-except ImportError:
-    # placeholder in case meshmode is too old to have it.
-    class _FirstAxisIsElementsTag(Tag):  # type: ignore[no-redef]
-        pass
+class CommonSubexpressionTag(Tag):
+    """A tag that is applicable to arrays indicating that this same array
+    may be evaluated multiple times, and that the implementation should
+    eliminate those redundant evaluations if possible.
+    """
 
 
-if sys.version_info >= (3, 7):
-    def __getattr__(name):
-        if name == "FirstAxisIsElementsTag":
-            warn(f"'arraycontext.{name}' is deprecated. "
-                    f"Use 'meshmode.transform_metadata.{name}' instead. "
-                    f"'arraycontext.{name}' will continue to work until 2022.",
-                    DeprecationWarning, stacklevel=2)
-            return _FirstAxisIsElementsTag
-        else:
-            raise AttributeError(name)
-else:
-    FirstAxisIsElementsTag = _FirstAxisIsElementsTag
+class ElementwiseMapKernelTag(Tag):
+    """A tag that applies to :class:`loopy.LoopKernel` indicating that the kernel
+    is a "map", i.e. that the output array(s) has/have the same shape as the
+    input array(s), and that each output element only depends on its corresponding
+    element(s) in the input array(s).
+
+    .. note::
+
+        "Element" here refers to a scalar element of an array, not an element
+        in a finite-element discretization.
+    """
 
 # }}}
 

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -31,18 +31,45 @@ from arraycontext import (
         dataclass_array_container, with_container_arithmetic,
         serialize_container, deserialize_container,
         freeze, thaw,
-        FirstAxisIsElementsTag)
+        FirstAxisIsElementsTag,
+        PyOpenCLArrayContext)
 from arraycontext import (  # noqa: F401
         pytest_generate_tests_for_array_contexts,
         _acf)
+from arraycontext.pytest import _PytestPyOpenCLArrayContextFactoryWithClass
+
 
 import logging
 logger = logging.getLogger(__name__)
 
 
+# {{{ array context fixture
+
+class _PyOpenCLArrayContextForTests(PyOpenCLArrayContext):
+    """Like :class:`PyOpenCLArrayContext`, but applies no program transformations
+    whatsoever. Only to be used for testing internal to :mod:`arraycontext`.
+    """
+
+    def transform_loopy_program(self, t_unit):
+        return t_unit
+
+
+class _PyOpenCLArrayContextWithHostScalarsForTestsFactory(
+        _PytestPyOpenCLArrayContextFactoryWithClass):
+    actx_class = _PyOpenCLArrayContextForTests
+
+
+class _PyOpenCLArrayContextForTestsFactory(
+        _PyOpenCLArrayContextWithHostScalarsForTestsFactory):
+    force_device_scalars = True
+
+
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
-    "pyopencl", "pyopencl-deprecated",
+    _PyOpenCLArrayContextForTestsFactory,
+    _PyOpenCLArrayContextWithHostScalarsForTestsFactory,
     ])
+
+# }}}
 
 
 # {{{ stand-in DOFArray implementation


### PR DESCRIPTION
This
* deprecates the idea that `PyOpenCLArrayContext` in `arraycontext` knows anything about how to transform kernels, delegating this to more usage-specific subclasses. The meshmode PR that goes with this is https://github.com/inducer/meshmode/pull/236.
* deprecates a bunch of FEM/DG-specific transform metadata.

This PR is probably best read commit-by-commit.