### PR TITLE
Test, fix equality-comparison behavior

### DIFF
--- a/arraycontext/container/arithmetic.py
+++ b/arraycontext/container/arithmetic.py
@@ -42,12 +42,12 @@ T = TypeVar("T")
 
 
 class _OpClass(enum.Enum):
-    ARITHMETIC = enum.auto
-    MATMUL = enum.auto
-    BITWISE = enum.auto
-    SHIFT = enum.auto
-    EQ_COMPARISON = enum.auto
-    REL_COMPARISON = enum.auto
+    ARITHMETIC = enum.auto()
+    MATMUL = enum.auto()
+    BITWISE = enum.auto()
+    SHIFT = enum.auto()
+    EQ_COMPARISON = enum.auto()
+    REL_COMPARISON = enum.auto()
 
 
 _UNARY_OP_AND_DUNDER = [

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -492,9 +492,10 @@ def test_array_context_einsum_array_tripleprod(actx_factory, spec):
 # }}}
 
 
-# {{{ test array container
+# {{{ array container classes for test
 
-@with_container_arithmetic(bcast_obj_array=False, rel_comparison=True)
+@with_container_arithmetic(bcast_obj_array=False,
+        eq_comparison=False, rel_comparison=False)
 @dataclass_array_container
 @dataclass(frozen=True)
 class MyContainer:
@@ -763,6 +764,23 @@ def test_norm_ord_none(actx_factory, ndim):
     norm_a = actx.np.linalg.norm(actx.from_numpy(a), ord=None)
 
     np.testing.assert_allclose(actx.to_numpy(norm_a), norm_a_ref)
+
+
+def test_container_equality(actx_factory):
+    actx = actx_factory()
+
+    ary_dof, _, _, dc_of_dofs, bcast_dc_of_dofs = \
+            _get_test_containers(actx)
+    _, _, _, dc_of_dofs_2, bcast_dc_of_dofs_2 = \
+            _get_test_containers(actx)
+
+    # MyContainer sets eq_comparison to False, so equality comparison should
+    # not succeed.
+    dc = MyContainer(name="yoink", mass=ary_dof, momentum=None, enthalpy=None)
+    dc2 = MyContainer(name="yoink", mass=ary_dof, momentum=None, enthalpy=None)
+    assert dc != dc2
+
+    assert isinstance(bcast_dc_of_dofs == bcast_dc_of_dofs_2, MyContainerDOFBcast)
 
 
 if __name__ == "__main__":

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -77,6 +77,7 @@ pytest_generate_tests = pytest_generate_tests_for_array_contexts([
 @with_container_arithmetic(
         bcast_obj_array=True,
         bcast_numpy_array=True,
+        bitwise=True,
         rel_comparison=True,
         _cls_has_array_context_attr=True)
 class DOFArray:


### PR DESCRIPTION
Closes #48.

Good thing I checked... turns out that there were multiple bugs here. First, the spurious-equality scenario from #48 was possible, though under somewhat contrived (and non-default) circumstances.

Next, I spotted that we were misusing `enum.auto` in a way that made all "operator classes" the same. (Yikes!)

This takes care of both of those and adds a test.