### PR TITLE
Overwrite abs to always return real outputs

### DIFF
--- a/arraycontext/fake_numpy.py
+++ b/arraycontext/fake_numpy.py
@@ -85,8 +85,10 @@ class BaseFakeNumpyNamespace:
         # "conj", "conjugate",
 
         # Miscellaneous
-        "convolve", "clip", "sqrt", "cbrt", "square", "absolute", "abs", "fabs",
+        "convolve", "clip", "sqrt", "cbrt", "square", "fabs",
         "sign", "heaviside", "maximum", "fmax", "nan_to_num",
+        # Implemented below:
+        # "abs", "absolute"
 
         # FIXME:
         # "interp",
@@ -164,6 +166,14 @@ class BaseFakeNumpyNamespace:
         return rec_map_array_container(lambda obj: obj.conj(), x)
 
     conj = conjugate
+
+    def absolute(self, ary):
+        # NOTE: `loopy_implemented_elwise_func` uses the dtype of the input
+        # to determine the dtype of the output, which fails for abs with
+        # complex inputs
+        return rec_map_array_container(abs, ary)
+
+    abs = absolute
 
 # }}}
 

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -739,6 +739,17 @@ def test_numpy_conversion(actx_factory):
 # }}}
 
 
+def test_abs_complex(actx_factory):
+    actx = actx_factory()
+    a = np.random.randn(2000) + 1j * np.random.randn(2000)
+
+    abs_a_ref = np.abs(a)
+    abs_a = actx.np.abs(actx.from_numpy(a))
+
+    assert abs_a.dtype == abs_a_ref.dtype
+    np.testing.assert_allclose(actx.to_numpy(abs_a), abs_a_ref)
+
+
 @pytest.mark.parametrize("norm_ord", [2, np.inf])
 def test_norm_complex(actx_factory, norm_ord):
     actx = actx_factory()


### PR DESCRIPTION
Hopefully helps with inducer/pytential#99.