### PR TITLE
Add generic container reductions

### DIFF
--- a/arraycontext/__init__.py
+++ b/arraycontext/__init__.py
@@ -52,8 +52,8 @@ from .container.traversal import (
         rec_multimap_array_container,
         mapped_over_array_containers,
         multimapped_over_array_containers,
-        rec_reduce_array_container,
-        rec_multireduce_array_container,
+        rec_map_reduce_array_container,
+        rec_multimap_reduce_array_container,
         thaw, freeze,
         from_numpy, to_numpy)
 
@@ -85,7 +85,7 @@ __all__ = (
         "rec_map_array_container", "rec_multimap_array_container",
         "mapped_over_array_containers",
         "multimapped_over_array_containers",
-        "rec_reduce_array_container", "rec_multireduce_array_container",
+        "rec_map_reduce_array_container", "rec_multimap_reduce_array_container",
         "thaw", "freeze",
         "from_numpy", "to_numpy",
 

--- a/arraycontext/__init__.py
+++ b/arraycontext/__init__.py
@@ -52,6 +52,8 @@ from .container.traversal import (
         rec_multimap_array_container,
         mapped_over_array_containers,
         multimapped_over_array_containers,
+        rec_reduce_array_container,
+        rec_multireduce_array_container,
         thaw, freeze,
         from_numpy, to_numpy)
 
@@ -83,6 +85,7 @@ __all__ = (
         "rec_map_array_container", "rec_multimap_array_container",
         "mapped_over_array_containers",
         "multimapped_over_array_containers",
+        "rec_reduce_array_container", "rec_multireduce_array_container",
         "thaw", "freeze",
         "from_numpy", "to_numpy",
 

--- a/arraycontext/container/__init__.py
+++ b/arraycontext/container/__init__.py
@@ -139,7 +139,7 @@ def is_array_container_type(cls: type) -> bool:
     return (
             cls is ArrayContainer
             or (serialize_container.dispatch(cls)
-                is not serialize_container.__wrapped__))    # type: ignore
+                is not serialize_container.__wrapped__))  # type:ignore[attr-defined]
 
 
 def is_array_container(ary: Any) -> bool:
@@ -148,7 +148,7 @@ def is_array_container(ary: Any) -> bool:
         :func:`serialize_container`.
     """
     return (serialize_container.dispatch(ary.__class__)
-            is not serialize_container.__wrapped__)         # type: ignore
+            is not serialize_container.__wrapped__)       # type:ignore[attr-defined]
 
 
 @singledispatch

--- a/arraycontext/container/traversal.py
+++ b/arraycontext/container/traversal.py
@@ -332,7 +332,7 @@ def rec_multimap_reduce_array_container(
         array of the same type or a scalar.
     """
     # NOTE: this wrapper matches the signature of `deserialize_container`
-    # to make pluggin into `_multimap_array_container_impl` easier
+    # to make plugging into `_multimap_array_container_impl` easier
     def _reduce_wrapper(ary: Any, iterable: Iterable[Tuple[Any, Any]]) -> Any:
         return reduce_func([subary for _, subary in iterable])
 

--- a/arraycontext/container/traversal.py
+++ b/arraycontext/container/traversal.py
@@ -8,8 +8,8 @@
 .. autofunction:: rec_map_array_container
 .. autofunction:: rec_multimap_array_container
 
-.. autofunction:: rec_reduce_array_container
-.. autofunction:: rec_multireduce_array_container
+.. autofunction:: rec_map_reduce_array_container
+.. autofunction:: rec_multimap_reduce_array_container
 
 Traversing decorators
 ~~~~~~~~~~~~~~~~~~~~~
@@ -294,15 +294,15 @@ def rec_keyed_map_array_container(f: Callable[[Tuple[Any, ...], Any], Any],
 
 # {{{ array container reductions
 
-def rec_reduce_array_container(
+def rec_map_reduce_array_container(
         reduce_func: Callable[[Iterable[Any]], Any],
-        array_func: Callable[[Any], Any],
+        map_func: Callable[[Any], Any],
         ary: ArrayContainerT) -> Any:
-    """Perform reductions over array containers recursively.
+    """Perform a map-reduce over array containers recursively.
 
     :param reduce_func: callable used to reduce over the components of the
         :class:`~arraycontext.ArrayContainer`.
-    :param array_func: callable used to reduce a single component of the
+    :param map_func: callable used to map a single component of the
         :class:`~arraycontext.ArrayContainer`. The callable takes arrays of
         type :class:`arraycontext.ArrayContext.array_types` and returns an
         array of the same type or a scalar.
@@ -313,20 +313,20 @@ def rec_reduce_array_container(
                 rec(subary) for _, subary in serialize_container(_ary)
                 ])
         else:
-            return array_func(_ary)
+            return map_func(_ary)
 
     return rec(ary)
 
 
-def rec_multireduce_array_container(
+def rec_multimap_reduce_array_container(
         reduce_func: Callable[[Iterable[Any]], Any],
-        array_func: Callable[..., Any],
+        map_func: Callable[..., Any],
         *args: Any) -> Any:
-    """Perform reductions over multiple array containers recursively.
+    """Perform a map-reduce over multiple array containers recursively.
 
     :param reduce_func: callable used to reduce over the components of the
         :class:`~arraycontext.ArrayContainer`.
-    :param array_func: callable used to reduce a single component of the
+    :param map_func: callable used to map a single component of the
         :class:`~arraycontext.ArrayContainer`. The callable takes arrays of
         type :class:`arraycontext.ArrayContext.array_types` and returns an
         array of the same type or a scalar.
@@ -337,7 +337,7 @@ def rec_multireduce_array_container(
         return reduce_func([subary for _, subary in iterable])
 
     return _multimap_array_container_impl(
-        array_func, *args,
+        map_func, *args,
         reduce_func=_reduce_wrapper, leaf_cls=None, recursive=True)
 
 # }}}

--- a/arraycontext/container/traversal.py
+++ b/arraycontext/container/traversal.py
@@ -130,7 +130,7 @@ def _multimap_array_container_impl(
 
             result.append((key, frec(*new_args)))       # type: ignore[operator]
 
-        return make_container(template_ary, result)     # type: ignore[operator]
+        return process_container(template_ary, result)     # type: ignore[operator]
 
     container_indices: List[int] = [
             i for i, arg in enumerate(args)
@@ -153,7 +153,7 @@ def _multimap_array_container_impl(
                 wrapper, template_ary,
                 leaf_cls=leaf_cls, recursive=recursive)
 
-    make_container = deserialize_container if reduce_func is None else reduce_func
+    process_container = deserialize_container if reduce_func is None else reduce_func
     frec = rec if recursive else f
 
     return rec(*args)

--- a/arraycontext/impl/pyopencl/fake_numpy.py
+++ b/arraycontext/impl/pyopencl/fake_numpy.py
@@ -26,13 +26,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from functools import partial
+from functools import partial, reduce
 import operator
 
 from arraycontext.fake_numpy import \
         BaseFakeNumpyNamespace, BaseFakeNumpyLinalgNamespace
-from arraycontext.container.traversal import (rec_multimap_array_container,
-                                              rec_map_array_container)
+from arraycontext.container.traversal import (
+        rec_multimap_array_container, rec_map_array_container,
+        rec_reduce_array_container,
+        )
 
 try:
     import pyopencl as cl  # noqa: F401
@@ -104,24 +106,35 @@ class PyOpenCLFakeNumpyNamespace(BaseFakeNumpyNamespace):
         return rec_multimap_array_container(where_inner, criterion, then, else_)
 
     def sum(self, a, dtype=None):
-        result = cl_array.sum(a, dtype=dtype, queue=self._array_context.queue)
+        result = rec_reduce_array_container(
+                sum,
+                partial(cl_array.sum, dtype=dtype, queue=self._array_context.queue),
+                a)
+
         if not self._array_context._force_device_scalars:
             result = result.get()[()]
-
         return result
 
     def min(self, a):
-        result = cl_array.min(a, queue=self._array_context.queue)
+        queue = self._array_context.queue
+        result = rec_reduce_array_container(
+                partial(reduce, partial(cl_array.minimum, queue=queue)),
+                partial(cl_array.min, queue=queue),
+                a)
+
         if not self._array_context._force_device_scalars:
             result = result.get()[()]
-
         return result
 
     def max(self, a):
-        result = cl_array.max(a, queue=self._array_context.queue)
+        queue = self._array_context.queue
+        result = rec_reduce_array_container(
+                partial(reduce, partial(cl_array.maximum, queue=queue)),
+                partial(cl_array.max, queue=queue),
+                a)
+
         if not self._array_context._force_device_scalars:
             result = result.get()[()]
-
         return result
 
     def stack(self, arrays, axis=0):
@@ -163,25 +176,15 @@ class PyOpenCLFakeNumpyNamespace(BaseFakeNumpyNamespace):
         return rec_map_array_container(_rec_ravel, a)
 
     def vdot(self, x, y, dtype=None):
-        import pyopencl.array as cl_array
-        from arraycontext import is_array_container, serialize_container
+        from arraycontext import rec_multireduce_array_container
+        result = rec_multireduce_array_container(
+                sum,
+                partial(cl_array.vdot, dtype=dtype, queue=self._array_context.queue),
+                x, y)
 
-        def _rec_vdot(xi, yi):
-            if is_array_container(xi):
-                assert type(xi) == type(yi)
-                return sum(_rec_vdot(subxi, subyi)
-                    for (_, subxi), (_, subyi) in zip(
-                        serialize_container(xi), serialize_container(yi)
-                    ))
-            else:
-                result = cl_array.vdot(xi, yi,
-                    dtype=dtype, queue=self._array_context.queue)
-                if not self._array_context._force_device_scalars:
-                    result = result.get()[()]
-
-                return result
-
-        return _rec_vdot(x, y)
+        if not self._array_context._force_device_scalars:
+            result = result.get()[()]
+        return result
 
 # }}}
 

--- a/arraycontext/impl/pyopencl/fake_numpy.py
+++ b/arraycontext/impl/pyopencl/fake_numpy.py
@@ -33,7 +33,7 @@ from arraycontext.fake_numpy import \
         BaseFakeNumpyNamespace, BaseFakeNumpyLinalgNamespace
 from arraycontext.container.traversal import (
         rec_multimap_array_container, rec_map_array_container,
-        rec_reduce_array_container,
+        rec_map_reduce_array_container,
         )
 
 try:
@@ -106,7 +106,7 @@ class PyOpenCLFakeNumpyNamespace(BaseFakeNumpyNamespace):
         return rec_multimap_array_container(where_inner, criterion, then, else_)
 
     def sum(self, a, dtype=None):
-        result = rec_reduce_array_container(
+        result = rec_map_reduce_array_container(
                 sum,
                 partial(cl_array.sum, dtype=dtype, queue=self._array_context.queue),
                 a)
@@ -117,7 +117,7 @@ class PyOpenCLFakeNumpyNamespace(BaseFakeNumpyNamespace):
 
     def min(self, a):
         queue = self._array_context.queue
-        result = rec_reduce_array_container(
+        result = rec_map_reduce_array_container(
                 partial(reduce, partial(cl_array.minimum, queue=queue)),
                 partial(cl_array.min, queue=queue),
                 a)
@@ -128,7 +128,7 @@ class PyOpenCLFakeNumpyNamespace(BaseFakeNumpyNamespace):
 
     def max(self, a):
         queue = self._array_context.queue
-        result = rec_reduce_array_container(
+        result = rec_map_reduce_array_container(
                 partial(reduce, partial(cl_array.maximum, queue=queue)),
                 partial(cl_array.max, queue=queue),
                 a)
@@ -176,8 +176,8 @@ class PyOpenCLFakeNumpyNamespace(BaseFakeNumpyNamespace):
         return rec_map_array_container(_rec_ravel, a)
 
     def vdot(self, x, y, dtype=None):
-        from arraycontext import rec_multireduce_array_container
-        result = rec_multireduce_array_container(
+        from arraycontext import rec_multimap_reduce_array_container
+        result = rec_multimap_reduce_array_container(
                 sum,
                 partial(cl_array.vdot, dtype=dtype, queue=self._array_context.queue),
                 x, y)

--- a/arraycontext/impl/pytato/fake_numpy.py
+++ b/arraycontext/impl/pytato/fake_numpy.py
@@ -28,7 +28,7 @@ from arraycontext.fake_numpy import (
         )
 from arraycontext.container.traversal import (
         rec_multimap_array_container, rec_map_array_container,
-        rec_reduce_array_container,
+        rec_map_reduce_array_container,
         )
 import pytato as pt
 
@@ -92,13 +92,15 @@ class PytatoFakeNumpyNamespace(BaseFakeNumpyNamespace):
 
             return pt.sum(ary)
 
-        return rec_reduce_array_container(sum, _pt_sum, a)
+        return rec_map_reduce_array_container(sum, _pt_sum, a)
 
     def min(self, a):
-        return rec_reduce_array_container(partial(reduce, pt.minimum), pt.amin, a)
+        return rec_map_reduce_array_container(
+                partial(reduce, pt.minimum), pt.amin, a)
 
     def max(self, a):
-        return rec_reduce_array_container(partial(reduce, pt.maximum), pt.amax, a)
+        return rec_map_reduce_array_container(
+                partial(reduce, pt.maximum), pt.amax, a)
 
     def stack(self, arrays, axis=0):
         return rec_multimap_array_container(

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -253,19 +253,27 @@ def assert_close_to_numpy_in_containers(actx, op, args):
 # {{{ np.function same as numpy
 
 @pytest.mark.parametrize(("sym_name", "n_args", "dtype"), [
-            ("sin", 1, np.float64),
-            ("sin", 1, np.complex128),
-            ("exp", 1, np.float64),
+            # float only
             ("arctan2", 2, np.float64),
             ("minimum", 2, np.float64),
             ("maximum", 2, np.float64),
             ("where", 3, np.float64),
+            ("min", 1, np.float64),
+            ("max", 1, np.float64),
+
+            # float + complex
+            ("sin", 1, np.float64),
+            ("sin", 1, np.complex128),
+            ("exp", 1, np.float64),
+            ("exp", 1, np.complex128),
             ("conj", 1, np.float64),
             ("conj", 1, np.complex128),
             ("vdot", 2, np.float64),
             ("vdot", 2, np.complex128),
             ("abs", 1, np.float64),
             ("abs", 1, np.complex128),
+            ("sum", 1, np.float64),
+            ("sum", 1, np.complex64),
             ])
 def test_array_context_np_workalike(actx_factory, sym_name, n_args, dtype):
     actx = actx_factory()
@@ -494,7 +502,7 @@ def test_dof_array_arithmetic_same_as_numpy(actx_factory):
 # {{{ reductions same as numpy
 
 @pytest.mark.parametrize("op", ["sum", "min", "max"])
-def test_dof_array_reductions_same_as_numpy(actx_factory, op):
+def test_reductions_same_as_numpy(actx_factory, op):
     actx = actx_factory()
 
     ary = np.random.randn(3000)


### PR DESCRIPTION
This adds some helpers to do reductions over array containers.

* adds a generic `rec_reduce_array_container(reduce_func, array_func, ary)` function.
* uses that in `actx.np.[sum, min, max]`.

Fixes #61.