### PR TITLE
JAXArrayContext

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ Python 3 POCL:
   script: |
     export PY_EXE=python3
     export PYOPENCL_TEST=portable:pthread
+    export EXTRA_INSTALL="jax[cpu]"
     curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/build-and-test-py-project.sh
     . ./build-and-test-py-project.sh
   tags:
@@ -18,6 +19,7 @@ Python 3 Nvidia Titan V:
   script: |
     export PY_EXE=python3
     export PYOPENCL_TEST=nvi:titan
+    export EXTRA_INSTALL="jax[cuda]"
     curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/build-and-test-py-project.sh
     . ./build-and-test-py-project.sh
   tags:
@@ -74,6 +76,7 @@ Flake8:
 Pylint:
   script: |
     export PY_EXE=python3
+    EXTRA_INSTALL="jax[cpu]"
     curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/master/prepare-and-run-pylint.sh
     . ./prepare-and-run-pylint.sh "$CI_PROJECT_NAME" examples/*.py test/test_*.py
   tags:

--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -13,3 +13,4 @@ dependencies:
 - pyopencl
 - islpy
 - pip
+- jax

--- a/arraycontext/__init__.py
+++ b/arraycontext/__init__.py
@@ -64,9 +64,13 @@ from .container.traversal import (
         outer)
 
 from .impl.pyopencl import PyOpenCLArrayContext
-from .impl.pytato import PytatoPyOpenCLArrayContext
+from .impl.pytato import (PytatoPyOpenCLArrayContext,
+                          PytatoJAXArrayContext,
+                          _BasePytatoArrayContext)
+from .impl.jax import EagerJAXArrayContext
 
 from .pytest import (
+        PytestArrayContextFactory,
         PytestPyOpenCLArrayContextFactory,
         pytest_generate_tests_for_array_contexts,
         pytest_generate_tests_for_pyopencl_array_context)
@@ -102,9 +106,12 @@ __all__ = (
         "outer",
 
         "PyOpenCLArrayContext", "PytatoPyOpenCLArrayContext",
+        "PytatoJAXArrayContext", "_BasePytatoArrayContext",
+        "EagerJAXArrayContext",
 
         "make_loopy_program",
 
+        "PytestArrayContextFactory",
         "PytestPyOpenCLArrayContextFactory",
         "pytest_generate_tests_for_array_contexts",
         "pytest_generate_tests_for_pyopencl_array_context"

--- a/arraycontext/__init__.py
+++ b/arraycontext/__init__.py
@@ -65,8 +65,7 @@ from .container.traversal import (
 
 from .impl.pyopencl import PyOpenCLArrayContext
 from .impl.pytato import (PytatoPyOpenCLArrayContext,
-                          PytatoJAXArrayContext,
-                          _BasePytatoArrayContext)
+                          PytatoJAXArrayContext)
 from .impl.jax import EagerJAXArrayContext
 
 from .pytest import (
@@ -106,7 +105,7 @@ __all__ = (
         "outer",
 
         "PyOpenCLArrayContext", "PytatoPyOpenCLArrayContext",
-        "PytatoJAXArrayContext", "_BasePytatoArrayContext",
+        "PytatoJAXArrayContext",
         "EagerJAXArrayContext",
 
         "make_loopy_program",

--- a/arraycontext/impl/jax/__init__.py
+++ b/arraycontext/impl/jax/__init__.py
@@ -1,0 +1,129 @@
+"""
+.. currentmodule:: arraycontext
+.. autoclass:: EagerJAXArrayContext
+"""
+
+__copyright__ = """
+Copyright (C) 2021 University of Illinois Board of Trustees
+"""
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import numpy as np
+
+from typing import Union, Callable, Any
+from pytools.tag import ToTagSetConvertible
+from arraycontext.context import ArrayContext, _ScalarLike
+
+
+class EagerJAXArrayContext(ArrayContext):
+    """
+    A :class:`ArrayContext` that uses
+    :class:`jaxlib.xla_extension.DeviceArrayBase` instances for its base array
+    class and performs all array operations eagerly. See
+    :class:`~arraycontext.PytatoJAXArrayContext` for a lazier version.
+
+    .. note::
+
+        JAX stores a global configuration state in :data:`jax.config`. Callers
+        are expected to maintain those. Most important for scientific computing
+        workloads being ``jax_enable_x64``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        from jax.numpy import DeviceArray
+        self.array_types = (DeviceArray, )
+
+    def _get_fake_numpy_namespace(self):
+        from .fake_numpy import EagerJAXFakeNumpyNamespace
+        return EagerJAXFakeNumpyNamespace(self)
+
+    # {{{ ArrayContext interface
+
+    def empty(self, shape, dtype):
+        import jax.numpy as jnp
+        return jnp.empty(shape=shape, dtype=dtype)
+
+    def zeros(self, shape, dtype):
+        import jax.numpy as jnp
+        return jnp.zeros(shape=shape, dtype=dtype)
+
+    def from_numpy(self, array: Union[np.ndarray, _ScalarLike]):
+        import jax
+        return jax.device_put(array)
+
+    def to_numpy(self, array):
+        import jax
+        # jax.device_get can take scalars as well.
+        return jax.device_get(array)
+
+    def call_loopy(self, t_unit, **kwargs):
+        raise NotImplementedError("calling loopy on JAX arrays"
+                                  " not supported. Maybe rewrite"
+                                  " the loopy kernel as numpy-flavored array"
+                                  " operations using ArrayContext.np.")
+
+    def freeze(self, array):
+        return array.block_until_ready()
+
+    def thaw(self, array):
+        return array
+
+    # }}}
+
+    def tag(self, tags: ToTagSetConvertible, array):
+        # Sorry, not capable.
+        return array
+
+    def tag_axis(self, iaxis, tags: ToTagSetConvertible, array):
+        # TODO: See `jax.experiemental.maps.xmap`, proabably that should be useful?
+        return array
+
+    def clone(self):
+        return type(self)()
+
+    def compile(self, f: Callable[..., Any]) -> Callable[..., Any]:
+        return f
+
+    def einsum(self, spec, *args, arg_names=None, tagged=()):
+        import jax.numpy as jnp
+        if arg_names is not None:
+            from warnings import warn
+            warn("'arg_names' don't bear any significance in "
+                 "EagerJAXArrayContext.", stacklevel=2)
+
+        return jnp.einsum(spec, *args)
+
+    @property
+    def permits_inplace_modification(self):
+        return False
+
+    @property
+    def supports_nonscalar_broadcasting(self):
+        return True
+
+    @property
+    def permits_advanced_indexing(self):
+        return True
+
+# vim: foldmethod=marker

--- a/arraycontext/impl/jax/fake_numpy.py
+++ b/arraycontext/impl/jax/fake_numpy.py
@@ -1,0 +1,143 @@
+__copyright__ = """
+Copyright (C) 2021 University of Illinois Board of Trustees
+"""
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+from functools import partial, reduce
+
+from arraycontext.fake_numpy import (
+        BaseFakeNumpyNamespace, BaseFakeNumpyLinalgNamespace,
+        )
+from arraycontext.container.traversal import (
+        rec_multimap_array_container, rec_map_array_container,
+        rec_map_reduce_array_container,
+        )
+from arraycontext.container import NotAnArrayContainerError, serialize_container
+import numpy
+import jax.numpy as jnp
+
+
+class EagerJAXFakeNumpyLinalgNamespace(BaseFakeNumpyLinalgNamespace):
+    # Everything is implemented in the base class for now.
+    pass
+
+
+class EagerJAXFakeNumpyNamespace(BaseFakeNumpyNamespace):
+    """
+    A :mod:`numpy` mimic for :class:`~arraycontext.EagerJAXArrayContext`.
+    """
+    def _get_fake_numpy_linalg_namespace(self):
+        return EagerJAXFakeNumpyLinalgNamespace(self._array_context)
+
+    def __getattr__(self, name):
+        return partial(rec_multimap_array_container, getattr(jnp, name))
+
+    def reshape(self, a, newshape, order="C"):
+        return rec_map_array_container(
+            lambda ary: jnp.reshape(ary, newshape, order=order),
+            a)
+
+    def transpose(self, a, axes=None):
+        return rec_multimap_array_container(jnp.transpose, a, axes)
+
+    def concatenate(self, arrays, axis=0):
+        return rec_multimap_array_container(jnp.concatenate, arrays, axis)
+
+    def where(self, criterion, then, else_):
+        return rec_multimap_array_container(jnp.where, criterion, then, else_)
+
+    def sum(self, a, axis=None, dtype=None):
+        return rec_map_reduce_array_container(sum,
+                                              partial(jnp.sum,
+                                                      axis=axis,
+                                                      dtype=dtype),
+                                              a)
+
+    def min(self, a, axis=None):
+        return rec_map_reduce_array_container(
+                partial(reduce, jnp.minimum), partial(jnp.amin, axis=axis), a)
+
+    def max(self, a, axis=None):
+        return rec_map_reduce_array_container(
+                partial(reduce, jnp.maximum), partial(jnp.amax, axis=axis), a)
+
+    def stack(self, arrays, axis=0):
+        return rec_multimap_array_container(
+            lambda *args: jnp.stack(arrays=args, axis=axis),
+            *arrays)
+
+    def array_equal(self, a, b):
+        actx = self._array_context
+
+        # NOTE: not all backends support `bool` properly, so use `int8` instead
+        false = actx.from_numpy(numpy.int8(False))
+
+        def rec_equal(x, y):
+            if type(x) != type(y):
+                return false
+
+            try:
+                iterable = zip(serialize_container(x), serialize_container(y))
+            except NotAnArrayContainerError:
+                if x.shape != y.shape:
+                    return false
+                else:
+                    return jnp.all(jnp.equal(x, y))
+            else:
+                return reduce(
+                        jnp.logical_and,
+                        [rec_equal(ix, iy) for (_, ix), (_, iy) in iterable]
+                        )
+
+        return rec_equal(a, b)
+
+    def ravel(self, a, order="C"):
+        """
+        .. warning::
+
+            Since :func:`jax.numpy.reshape` does not support orders `A`` and
+            ``K``, in such cases we fallback to using ``order = C``.
+        """
+        if order in "AK":
+            from warnings import warn
+            warn(f"ravel with order='{order}' not supported by JAX,"
+                 " using order=C.")
+            order = "C"
+
+        return rec_map_array_container(lambda subary: jnp.ravel(subary, order=order),
+                                       a)
+
+    def vdot(self, x, y, dtype=None):
+        from arraycontext import rec_multimap_reduce_array_container
+
+        def _rec_vdot(ary1, ary2):
+            if dtype not in [None, numpy.find_common_type((ary1.dtype,
+                                                           ary2.dtype),
+                                                          ())]:
+                raise NotImplementedError(f"{type(self)} cannot take dtype in"
+                                          " vdot.")
+
+            return jnp.vdot(ary1, ary2)
+
+        return rec_multimap_reduce_array_container(sum, _rec_vdot, x, y)
+
+    def broadcast_to(self, array, shape):
+        return rec_map_array_container(partial(jnp.broadcast_to, shape=shape), array)

--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -10,6 +10,7 @@ JIT-compile and execute the array expressions.
 Following :mod:`pytato`-based array context are provided:
 
 .. autoclass:: PytatoPyOpenCLArrayContext
+.. autoclass:: PytatoJAXArrayContext
 
 
 Compiling a python callable
@@ -44,14 +45,85 @@ THE SOFTWARE.
 from arraycontext.context import ArrayContext, _ScalarLike
 from arraycontext.container.traversal import rec_map_array_container
 import numpy as np
-from typing import Any, Callable, Union, TYPE_CHECKING
+from typing import Any, Callable, Union, TYPE_CHECKING, Tuple, Type
 from pytools.tag import ToTagSetConvertible
+import abc
 
 if TYPE_CHECKING:
     import pytato
 
 
-class PytatoPyOpenCLArrayContext(ArrayContext):
+class _BasePytatoArrayContext(ArrayContext, abc.ABC):
+    """
+    An abstract :class:`ArrayContext` that uses :mod:`pytato` data types to
+    represent.
+
+    .. automethod:: __init__
+
+    .. automethod:: transform_dag
+
+    .. automethod:: compile
+    """
+    def __init__(self):
+        super().__init__()
+        self._freeze_prg_cache = {}
+        self._dag_transform_cache = {}
+
+    def _get_fake_numpy_namespace(self):
+        from arraycontext.impl.pytato.fake_numpy import PytatoFakeNumpyNamespace
+        return PytatoFakeNumpyNamespace(self)
+
+    def empty(self, shape, dtype):
+        raise ValueError(f"{type(self).__name__} does not support empty")
+
+    def zeros(self, shape, dtype):
+        import pytato as pt
+        return pt.zeros(shape, dtype)
+
+    def transform_dag(self, dag: "pytato.DictOfNamedArrays"
+                      ) -> "pytato.DictOfNamedArrays":
+        """
+        Returns a transformed version of *dag*. Sub-classes are supposed to
+        override this method to implement context-specific transformations on
+        *dag* (most likely to perform domain-specific optimizations). Every
+        :mod:`pytato` DAG that is compiled to a GPU-kernel is
+        passed through this routine.
+
+        :arg dag: An instance of :class:`pytato.DictOfNamedArrays`
+        :returns: A transformed version of *dag*.
+        """
+        return dag
+
+    def transform_loopy_program(self, t_unit):
+        raise ValueError(f"{type(self)} does not implement "
+                         "transform_loopy_program. Sub-classes are supposed "
+                         "to implement it.")
+
+    @abc.abstractproperty
+    def frozen_array_types(self) -> Tuple[Type, ...]:
+        """
+        Returns valid frozen array types for the array context.
+        """
+        pass
+
+    @abc.abstractmethod
+    def einsum(self, spec, *args, arg_names=None, tagged=()):
+        pass
+
+    @property
+    def permits_inplace_modification(self):
+        return False
+
+    @property
+    def supports_nonscalar_broadcasting(self):
+        return True
+
+    @property
+    def permits_advanced_indexing(self):
+        return True
+
+
+class PytatoPyOpenCLArrayContext(_BasePytatoArrayContext):
     """
     A :class:`ArrayContext` that uses :mod:`pytato` data types to represent
     the arrays targeting OpenCL for offloading operations.
@@ -79,27 +151,14 @@ class PytatoPyOpenCLArrayContext(ArrayContext):
         self.queue = queue
         self.allocator = allocator
         self.array_types = (pt.Array, cla.Array)
-        self._freeze_prg_cache = {}
-        self._dag_transform_cache = {}
 
         # unused, but necessary to keep the context alive
         self.context = self.queue.context
-
-    def _get_fake_numpy_namespace(self):
-        from arraycontext.impl.pytato.fake_numpy import PytatoFakeNumpyNamespace
-        return PytatoFakeNumpyNamespace(self)
 
     # {{{ ArrayContext interface
 
     def clone(self):
         return type(self)(self.queue, self.allocator)
-
-    def empty(self, shape, dtype):
-        raise ValueError("PytatoPyOpenCLArrayContext does not support empty")
-
-    def zeros(self, shape, dtype):
-        import pytato as pt
-        return pt.zeros(shape, dtype)
 
     def from_numpy(self, array: Union[np.ndarray, _ScalarLike]):
         import pytato as pt
@@ -113,6 +172,11 @@ class PytatoPyOpenCLArrayContext(ArrayContext):
 
         cl_array = self.freeze(array)
         return cl_array.get(queue=self.queue)
+
+    @property
+    def frozen_array_types(self) -> Tuple[Type, ...]:
+        import pyopencl.array as cla
+        return (cla.Array, )
 
     def call_loopy(self, program, **kwargs):
         import pytato as pt
@@ -167,8 +231,8 @@ class PytatoPyOpenCLArrayContext(ArrayContext):
                                       axes=get_cl_axes_from_pt_axes(array.axes),
                                       tags=array.tags)
         if not isinstance(array, pt.Array):
-            raise TypeError("PytatoPyOpenCLArrayContext.freeze invoked with "
-                            f"non-pytato array of type '{type(array)}'")
+            raise TypeError(f"{type(self).__name__}.freeze invoked "
+                            f"with non-pytato array of type '{type(array)}'")
 
         # {{{ early exit for 0-sized arrays
 
@@ -227,7 +291,7 @@ class PytatoPyOpenCLArrayContext(ArrayContext):
         elif isinstance(array, cl_array.Array):
             array = to_tagged_cl_array(array, axes=None, tags=frozenset())
         else:
-            raise TypeError("PytatoPyOpenCLArrayContext.thaw expects "
+            raise TypeError(f"{type(self).__name__}.thaw expects "
                             "'TaggableCLArray' or 'cl.array.Array' got "
                             f"{type(array)}.")
 
@@ -238,30 +302,13 @@ class PytatoPyOpenCLArrayContext(ArrayContext):
     # }}}
 
     def compile(self, f: Callable[..., Any]) -> Callable[..., Any]:
-        from arraycontext.impl.pytato.compile import LazilyCompilingFunctionCaller
-        return LazilyCompilingFunctionCaller(self, f)
-
-    def transform_loopy_program(self, t_unit):
-        raise ValueError("PytatoPyOpenCLArrayContext does not implement "
-                         "transform_loopy_program. Sub-classes are supposed "
-                         "to implement it.")
+        from .compile import LazilyPyOpenCLCompilingFunctionCaller
+        return LazilyPyOpenCLCompilingFunctionCaller(self, f)
 
     def transform_dag(self, dag: "pytato.DictOfNamedArrays"
                       ) -> "pytato.DictOfNamedArrays":
-        """
-        Returns a transformed version of *dag*. Sub-classes are supposed to
-        override this method to implement context-specific transformations on
-        *dag* (most likely to perform domain-specific optimizations). Every
-        :mod:`pytato` DAG that is compiled to a :mod:`pyopencl` kernel is
-        passed through this routine.
-
-        :arg dag: An instance of :class:`pytato.DictOfNamedArrays`
-        :returns: A transformed version of *dag*.
-        """
         import pytato as pt
-
         dag = pt.transform.materialize_with_mpms(dag)
-
         return dag
 
     def tag(self, tags: ToTagSetConvertible, array):
@@ -315,14 +362,139 @@ class PytatoPyOpenCLArrayContext(ArrayContext):
             for name, arg in zip(arg_names, args)
             ])
 
-    @property
-    def permits_inplace_modification(self):
-        return False
+
+class PytatoJAXArrayContext(_BasePytatoArrayContext):
+    """
+    An arraycontext that uses :mod:`pytato` to represent the thawed state of
+    the arrays and compiles the expressions using
+    :class:`pytato.target.python.JAXPythonTarget`.
+    """
+
+    def __init__(self):
+        import pytato as pt
+        from jax.numpy import DeviceArray
+        super().__init__()
+        self.array_types = (pt.Array, DeviceArray)
+
+    def clone(self):
+        return type(self)()
+
+    def from_numpy(self, array: Union[np.ndarray, _ScalarLike]):
+        import jax
+        import pytato as pt
+        return pt.make_data_wrapper(jax.device_put(array))
+
+    def to_numpy(self, array):
+        if np.isscalar(array):
+            return array
+
+        import jax
+        return jax.device_get(self.freeze(array))
 
     @property
-    def supports_nonscalar_broadcasting(self):
-        return True
+    def frozen_array_types(self) -> Tuple[Type, ...]:
+        from jax.numpy import DeviceArray
+        return (DeviceArray, )
 
-    @property
-    def permits_advanced_indexing(self):
-        return True
+    def call_loopy(self, program, **kwargs):
+        raise ValueError(f"{type(self)} does not support calling loopy.")
+
+    def freeze(self, array):
+        import pytato as pt
+        from jax.numpy import DeviceArray
+
+        if isinstance(array, DeviceArray):
+            return array.block_until_ready()
+        if not isinstance(array, pt.Array):
+            raise TypeError(f"{type(self)}.freeze invoked with "
+                            f"non-pytato array of type '{type(array)}'")
+
+        from arraycontext.impl.pytato.utils import _normalize_pt_expr
+        pt_dict_of_named_arrays = pt.make_dict_of_named_arrays(
+                {"_actx_out": array})
+
+        normalized_expr, bound_arguments = _normalize_pt_expr(
+                pt_dict_of_named_arrays)
+
+        try:
+            pt_prg = self._freeze_prg_cache[normalized_expr]
+        except KeyError:
+            pt_prg = pt.generate_jax(self.transform_dag(normalized_expr),
+                                     jit=True)
+            self._freeze_prg_cache[normalized_expr] = pt_prg
+
+        assert len(pt_prg.bound_arguments) == 0
+        out_dict = pt_prg(**bound_arguments)
+
+        return out_dict["_actx_out"].block_until_ready()
+
+    def thaw(self, array):
+        import pytato as pt
+
+        if not isinstance(array, self.frozen_array_types):
+            raise TypeError(f"{type(self)}.thaw expects jax device arrays, got "
+                            f"{type(array)}")
+
+        return pt.make_data_wrapper(array)
+
+    def compile(self, f: Callable[..., Any]) -> Callable[..., Any]:
+        from .compile import LazilyJAXCompilingFunctionCaller
+        return LazilyJAXCompilingFunctionCaller(self, f)
+
+    def tag(self, tags: ToTagSetConvertible, array):
+        import pytato as pt
+        from jax.numpy import DeviceArray
+
+        def _rec_tag(ary):
+            if isinstance(ary, DeviceArray):
+                return ary
+            else:
+                assert isinstance(ary, pt.Array)
+                return ary.tagged(tags)
+
+        return rec_map_array_container(_rec_tag, array)
+
+    def tag_axis(self, iaxis, tags: ToTagSetConvertible, array):
+        import pytato as pt
+        from jax.numpy import DeviceArray
+
+        def _rec_tag_axis(ary):
+            if isinstance(ary, DeviceArray):
+                return ary
+            else:
+                assert isinstance(ary, pt.Array)
+                return ary.with_tagged_axis(iaxis, tags)
+
+        return rec_map_array_container(_rec_tag_axis,
+                                       array)
+
+    def einsum(self, spec, *args, arg_names=None, tagged=()):
+        import pytato as pt
+        from jax.numpy import DeviceArray
+        if arg_names is None:
+            arg_names = (None,) * len(args)
+
+        def preprocess_arg(name, arg):
+            if isinstance(arg, DeviceArray):
+                ary = self.thaw(arg)
+            else:
+                assert isinstance(arg, pt.Array)
+                ary = arg
+
+            if name is not None:
+                from pytato.tags import PrefixNamed
+
+                # Tagging Placeholders with naming-related tags is pointless:
+                # They already have names. It's also counterproductive, as
+                # multiple placeholders with the same name that are not
+                # also the same object are not allowed, and this would produce
+                # a different Placeholder object of the same name.
+                if not isinstance(ary, pt.Placeholder):
+                    ary = ary.tagged(PrefixNamed(name))
+
+            return ary
+
+        return pt.einsum(spec, *[
+            preprocess_arg(name, arg)
+            for name, arg in zip(arg_names, args)
+            ])

--- a/doc/array_context.rst
+++ b/doc/array_context.rst
@@ -19,6 +19,12 @@ Lazy/Deferred evaluation array context based on :mod:`pytato`
 
 .. automodule:: arraycontext.impl.pytato
 
+
+Array context :mod:`jax.numpy`
+-------------------------------------------------------------
+
+.. automodule:: arraycontext.impl.jax
+
 .. _numpy-coverage:
 
 :mod:`numpy` coverage

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,6 +24,7 @@ intersphinx_mapping = {
     "https://documen.tician.de/loopy": None,
     "https://documen.tician.de/meshmode": None,
     "https://docs.pytest.org/en/latest/": None,
+    "https://jax.readthedocs.io/en/latest/": None,
 }
 
 import sys

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -42,7 +42,9 @@ from arraycontext import (  # noqa: F401
         pytest_generate_tests_for_array_contexts,
         )
 from arraycontext.pytest import (_PytestPyOpenCLArrayContextFactoryWithClass,
-                                 _PytestPytatoPyOpenCLArrayContextFactory)
+                                 _PytestPytatoPyOpenCLArrayContextFactory,
+                                 _PytestEagerJaxArrayContextFactory,
+                                 _PytestPytatoJaxArrayContextFactory)
 
 
 import logging
@@ -89,6 +91,8 @@ pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     _PyOpenCLArrayContextForTestsFactory,
     _PyOpenCLArrayContextWithHostScalarsForTestsFactory,
     _PytatoPyOpenCLArrayContextForTestsFactory,
+    _PytestEagerJaxArrayContextFactory,
+    _PytestPytatoJaxArrayContextFactory,
     ])
 
 
@@ -291,7 +295,6 @@ def assert_close_to_numpy_in_containers(actx, op, args):
             ("any", 1, np.float64),
             ("all", 1, np.float64),
             ("arctan", 1, np.float64),
-            ("atan", 1, np.float64),
 
             # float + complex
             ("sin", 1, np.float64),


### PR DESCRIPTION
TODO:
- <del>[ ] Map loopy IR to python callable consisting of non-stateful array operations.</del>
  - Dropping because translating logic is complicated, most likely unnecessary.
- [x] Test JAXArrayContext
- [x] Needs https://github.com/inducer/pytato/pull/233