### PR TITLE
PytatoArrayContext.compile: Improve scalar dtype guess

### DIFF
--- a/arraycontext/impl/pytato/compile.py
+++ b/arraycontext/impl/pytato/compile.py
@@ -110,7 +110,7 @@ def _get_arg_id_to_arg_and_arg_id_to_descr(args: Tuple[Any, ...]
         if np.isscalar(arg):
             arg_id = (iarg,)
             arg_id_to_arg[arg_id] = arg
-            arg_id_to_descr[arg_id] = ScalarInputDescriptor(np.dtype(arg))
+            arg_id_to_descr[arg_id] = ScalarInputDescriptor(np.dtype(type(arg)))
         elif is_array_container(arg):
             def id_collector(keys, ary):
                 arg_id = (iarg,) + keys
@@ -136,7 +136,7 @@ def _get_f_placeholder_args(arg, iarg, arg_id_to_name):
     """
     if np.isscalar(arg):
         name = arg_id_to_name[(iarg,)]
-        return pt.make_placeholder(name, (), np.dtype(arg))
+        return pt.make_placeholder(name, (), np.dtype(type(arg)))
     elif is_array_container(arg):
         def _rec_to_placeholder(keys, ary):
             name = arg_id_to_name[(iarg,) + keys]

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -891,6 +891,24 @@ def test_actx_compile(actx_factory):
     np.testing.assert_allclose(result.u, -3.14*v_y)
     np.testing.assert_allclose(result.v, 3.14*v_x)
 
+
+def test_actx_compile_python_scalar(actx_factory):
+    from arraycontext import (to_numpy, from_numpy)
+    actx = actx_factory()
+
+    compiled_rhs = actx.compile(scale_and_orthogonalize)
+
+    v_x = np.random.rand(10)
+    v_y = np.random.rand(10)
+
+    vel = from_numpy(Velocity2D(v_x, v_y, actx), actx)
+
+    scaled_speed = compiled_rhs(3.14, vel)
+
+    result = to_numpy(scaled_speed, actx)
+    np.testing.assert_allclose(result.u, -3.14*v_y)
+    np.testing.assert_allclose(result.v, 3.14*v_x)
+
 # }}}
 
 


### PR DESCRIPTION
Provided test fails on [`main`](https://github.com/inducer/arraycontext/tree/5187a0a5ab1be78b801f3f6941570f4d57f3fdd5).