### PR TITLE
Allow actx.np.real on real arrays

### DIFF
--- a/arraycontext/impl/pyopencl/fake_numpy.py
+++ b/arraycontext/impl/pyopencl/fake_numpy.py
@@ -208,6 +208,9 @@ class PyOpenCLFakeNumpyNamespace(BaseFakeNumpyNamespace):
             result = result.get()[()]
         return result
 
+    def real(self, ary):
+        return rec_map_array_container(lambda subary: subary.real, ary)
+
 # }}}
 
 

--- a/arraycontext/impl/pytato/fake_numpy.py
+++ b/arraycontext/impl/pytato/fake_numpy.py
@@ -127,8 +127,13 @@ class PytatoFakeNumpyNamespace(BaseFakeNumpyNamespace):
     def less_equal(self, x, y):
         return rec_multimap_array_container(pt.less_equal, x, y)
 
+    # }}}
+
     def conj(self, x):
         return rec_multimap_array_container(pt.conj, x)
+
+    def real(self, x):
+        return rec_multimap_array_container(pt.real, x)
 
     def arctan2(self, y, x):
         return rec_multimap_array_container(pt.arctan2, y, x)
@@ -154,5 +159,3 @@ class PytatoFakeNumpyNamespace(BaseFakeNumpyNamespace):
                                  f"(got {order})")
 
         return rec_map_array_container(_rec_ravel, a)
-
-    # }}}

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -284,6 +284,8 @@ def assert_close_to_numpy_in_containers(actx, op, args):
             ("abs", 1, np.complex128),
             ("sum", 1, np.float64),
             ("sum", 1, np.complex64),
+            ("real", 1, np.float64),
+            ("real", 1, np.complex128),
             ])
 def test_array_context_np_workalike(actx_factory, sym_name, n_args, dtype):
     actx = actx_factory()


### PR DESCRIPTION
For some reason loopy (in [loopy_implemented_elwise_func](https://github.com/inducer/arraycontext/blob/35dc261453985a96df1cb05aa4d4c06d0b25eb9e/arraycontext/fake_numpy.py#L149-L155)) wasn't able to infer the output type of `real` when acting on real arrays. There's probably a better fix for this somewhere down the stack, but in the meantime.

For context, hit this while trying to use [pytential.norm](https://github.com/inducer/pytential/blob/a09934a89e00bb4bbbaebd435e01f02b2fa2e5e9/pytential/__init__.py#L77).