### PR TITLE
Fix map_array_container on non-ArrayContainers

### DIFF
--- a/arraycontext/container/__init__.py
+++ b/arraycontext/container/__init__.py
@@ -135,7 +135,7 @@ def serialize_container(ary: ArrayContainer) -> Iterable[Tuple[Any, Any]]:
         for arbitrarily nested structures. The identifiers need to be hashable
         but are otherwise treated as opaque.
     """
-    raise NotImplementedError(type(ary).__name__)
+    raise TypeError(f"'{type(ary).__name__}' cannot be serialized as a container")
 
 
 @singledispatch
@@ -148,7 +148,8 @@ def deserialize_container(template: Any, iterable: Iterable[Tuple[Any, Any]]) ->
     :param iterable: an iterable that mirrors the output of
         :meth:`serialize_container`.
     """
-    raise NotImplementedError(type(template).__name__)
+    raise TypeError(
+            f"'{type(template).__name__}' cannot be deserialized as a container")
 
 
 def is_array_container_type(cls: type) -> bool:
@@ -190,7 +191,7 @@ def get_container_context(ary: ArrayContainer) -> Optional[ArrayContext]:
 def _serialize_ndarray_container(ary: np.ndarray) -> Iterable[Tuple[Any, Any]]:
     if ary.dtype.char != "O":
         raise ValueError(
-                f"only object arrays are supported, given dtype '{ary.dtype}'")
+                f"cannot seriealize '{type(ary).__name__}' with dtype '{ary.dtype}'")
 
     # special-cased for speed
     if ary.ndim == 1:

--- a/arraycontext/container/traversal.py
+++ b/arraycontext/container/traversal.py
@@ -180,7 +180,7 @@ def map_array_container(
     """
     try:
         iterable = serialize_container(ary)
-    except NotImplementedError:
+    except TypeError:
         return f(ary)
     else:
         return deserialize_container(ary, [
@@ -265,7 +265,7 @@ def keyed_map_array_container(f: Callable[[Any, Any], Any],
     """
     try:
         iterable = serialize_container(ary)
-    except NotImplementedError:
+    except TypeError:
         raise ValueError(
                 f"Non-array container type has no key: {type(ary).__name__}")
     else:
@@ -287,7 +287,7 @@ def rec_keyed_map_array_container(f: Callable[[Tuple[Any, ...], Any], Any],
             _ary: ArrayOrContainerT) -> ArrayOrContainerT:
         try:
             iterable = serialize_container(_ary)
-        except NotImplementedError:
+        except TypeError:
             return f(keys, _ary)
         else:
             return deserialize_container(_ary, [
@@ -316,7 +316,7 @@ def map_reduce_array_container(
     """
     try:
         iterable = serialize_container(ary)
-    except NotImplementedError:
+    except TypeError:
         return map_func(ary)
     else:
         return reduce_func([
@@ -391,7 +391,7 @@ def rec_map_reduce_array_container(
     def rec(_ary: ArrayOrContainerT) -> ArrayOrContainerT:
         try:
             iterable = serialize_container(_ary)
-        except NotImplementedError:
+        except TypeError:
             return map_func(_ary)
         else:
             return reduce_func([
@@ -483,7 +483,7 @@ def thaw(ary: ArrayOrContainerT, actx: ArrayContext) -> ArrayOrContainerT:
     """
     try:
         iterable = serialize_container(ary)
-    except NotImplementedError:
+    except TypeError:
         return actx.thaw(ary)
     else:
         return deserialize_container(ary, [

--- a/arraycontext/container/traversal.py
+++ b/arraycontext/container/traversal.py
@@ -179,12 +179,13 @@ def map_array_container(
         or an instance of a base array type.
     """
     try:
-        ser_ctr = serialize_container(ary)
-    except TypeError:
+        iterable = serialize_container(ary)
+    except NotImplementedError:
         return f(ary)
     else:
         return deserialize_container(ary, [
-                (key, f(subary)) for key, subary in ser_ctr])
+            (key, f(subary)) for key, subary in iterable
+            ])
 
 
 def multimap_array_container(f: Callable[..., Any], *args: Any) -> Any:
@@ -262,12 +263,15 @@ def keyed_map_array_container(f: Callable[[Any, Any], Any],
     :param ary: a (potentially nested) structure of :class:`ArrayContainer`\ s,
         or an instance of a base array type.
     """
-    if is_array_container(ary):
-        return deserialize_container(ary, [
-                (key, f(key, subary)) for key, subary in serialize_container(ary)
-                ])
+    try:
+        iterable = serialize_container(ary)
+    except NotImplementedError:
+        raise ValueError(
+                f"Non-array container type has no key: {type(ary).__name__}")
     else:
-        raise ValueError("Not an array-container, i.e. unknown key to pass.")
+        return deserialize_container(ary, [
+            (key, f(key, subary)) for key, subary in iterable
+            ])
 
 
 def rec_keyed_map_array_container(f: Callable[[Tuple[Any, ...], Any], Any],
@@ -281,13 +285,14 @@ def rec_keyed_map_array_container(f: Callable[[Tuple[Any, ...], Any], Any],
 
     def rec(keys: Tuple[Union[str, int], ...],
             _ary: ArrayOrContainerT) -> ArrayOrContainerT:
-        if is_array_container(_ary):
-            return deserialize_container(_ary, [
-                    (key, rec(keys + (key,), subary))
-                    for key, subary in serialize_container(_ary)
-                    ])
-        else:
+        try:
+            iterable = serialize_container(_ary)
+        except NotImplementedError:
             return f(keys, _ary)
+        else:
+            return deserialize_container(_ary, [
+                (key, rec(keys + (key,), subary)) for key, subary in iterable
+                ])
 
     return rec((), ary)
 
@@ -309,12 +314,14 @@ def map_reduce_array_container(
         :class:`arraycontext.ArrayContext.array_types`. Returns an array of the
         same type or a scalar.
     """
-    if is_array_container(ary):
-        return reduce_func([
-            map_func(subary) for _, subary in serialize_container(ary)
-            ])
-    else:
+    try:
+        iterable = serialize_container(ary)
+    except NotImplementedError:
         return map_func(ary)
+    else:
+        return reduce_func([
+            map_func(subary) for _, subary in iterable
+            ])
 
 
 def multimap_reduce_array_container(
@@ -382,12 +389,14 @@ def rec_map_reduce_array_container(
         or any other such traversal.
     """
     def rec(_ary: ArrayOrContainerT) -> ArrayOrContainerT:
-        if is_array_container(_ary):
-            return reduce_func([
-                rec(subary) for _, subary in serialize_container(_ary)
-                ])
-        else:
+        try:
+            iterable = serialize_container(_ary)
+        except NotImplementedError:
             return map_func(_ary)
+        else:
+            return reduce_func([
+                rec(subary) for _, subary in iterable
+                ])
 
     return rec(ary)
 
@@ -472,13 +481,14 @@ def thaw(ary: ArrayOrContainerT, actx: ArrayContext) -> ArrayOrContainerT:
         in :mod:`meshmode`. This was necessary because
         :func:`~functools.singledispatch` only dispatches on the first argument.
     """
-    if is_array_container(ary):
-        return deserialize_container(ary, [
-            (key, thaw(subary, actx))
-            for key, subary in serialize_container(ary)
-            ])
-    else:
+    try:
+        iterable = serialize_container(ary)
+    except NotImplementedError:
         return actx.thaw(ary)
+    else:
+        return deserialize_container(ary, [
+            (key, thaw(subary, actx)) for key, subary in iterable
+            ])
 
 # }}}
 

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -134,6 +134,9 @@ class DOFArray:
     def __getitem__(self, i):
         return self.data[i]
 
+    def __repr__(self):
+        return f"DOFArray({repr(self.data)})"
+
     @classmethod
     def _serialize_init_arrays_code(cls, instance_name):
         return {"_":
@@ -669,31 +672,57 @@ class MyContainerDOFBcast:
         return self.mass.array_context
 
 
-def _get_test_containers(actx, ambient_dim=2):
-    x = DOFArray(actx, (actx.from_numpy(np.random.randn(50_000)),))
+def _get_test_containers(actx, ambient_dim=2, size=50_000):
+    if size == 0:
+        x = DOFArray(actx, (actx.from_numpy(np.array(np.random.randn())),))
+    else:
+        x = DOFArray(actx, (actx.from_numpy(np.random.randn(size)),))
 
     # pylint: disable=unexpected-keyword-arg, no-value-for-parameter
     dataclass_of_dofs = MyContainer(
             name="container",
             mass=x,
-            momentum=make_obj_array([x, x]),
+            momentum=make_obj_array([x] * ambient_dim),
             enthalpy=x)
 
     # pylint: disable=unexpected-keyword-arg, no-value-for-parameter
     bcast_dataclass_of_dofs = MyContainerDOFBcast(
             name="container",
             mass=x,
-            momentum=make_obj_array([x, x]),
+            momentum=make_obj_array([x] * ambient_dim),
             enthalpy=x)
 
     ary_dof = x
-    ary_of_dofs = make_obj_array([x, x, x])
-    mat_of_dofs = np.empty((3, 3), dtype=object)
+    ary_of_dofs = make_obj_array([x] * ambient_dim)
+    mat_of_dofs = np.empty((ambient_dim, ambient_dim), dtype=object)
     for i in np.ndindex(mat_of_dofs.shape):
         mat_of_dofs[i] = x
 
     return (ary_dof, ary_of_dofs, mat_of_dofs, dataclass_of_dofs,
             bcast_dataclass_of_dofs)
+
+
+def test_container_scalar_map(actx_factory):
+    actx = actx_factory()
+
+    arys = _get_test_containers(actx, size=0)
+    arys += (np.pi,)
+
+    from arraycontext import (
+            map_array_container, rec_map_array_container,
+            map_reduce_array_container, rec_map_reduce_array_container,
+            )
+
+    for ary in arys:
+        result = map_array_container(lambda x: x, ary)
+        assert result is not None
+        result = rec_map_array_container(lambda x: x, ary)
+        assert result is not None
+
+        result = map_reduce_array_container(np.shape, lambda x: x, ary)
+        assert result is not None
+        result = rec_map_reduce_array_container(np.shape, lambda x: x, ary)
+        assert result is not None
 
 
 def test_container_multimap(actx_factory):
@@ -783,10 +812,11 @@ def test_container_arithmetic(actx_factory):
 
     grad_matvec_result = mock_gradient @ ary_of_dofs
     assert isinstance(grad_matvec_result.mass, DOFArray)
-    assert grad_matvec_result.momentum.shape == (3,)
+    assert grad_matvec_result.momentum.shape == ary_of_dofs.shape
 
-    assert actx.to_numpy(actx.np.linalg.norm(grad_matvec_result.mass
-                                             - 3*ary_of_dofs**2)) < 1e-8
+    assert actx.to_numpy(actx.np.linalg.norm(
+        grad_matvec_result.mass - sum(ary_of_dofs**2)
+        )) < 1e-8
 
     # }}}
 


### PR DESCRIPTION
`map_array_container` was using `try ... except` to check if an object is serializable, but it was only catching `TypeError`, not `NotImplementedError` thrown by `serialize_container`. That basically made it try to deserialize floats and other non-array container objects.

The `try ... except` was introduced in #31, seemingly for some performance reasons (?), so I went ahead and used the same pattern in several other places.

@thomasgibson as this is (now, vaguely) related to inducer/grudge#154.