### PR TITLE
Deprecate with_container_arithmetic's bcast_numpy_array arg

### DIFF
--- a/arraycontext/container/arithmetic.py
+++ b/arraycontext/container/arithmetic.py
@@ -206,6 +206,15 @@ def with_container_arithmetic(
     if rel_comparison is None:
         raise TypeError("rel_comparison must be specified")
 
+    if bcast_numpy_array:
+        from warnings import warn
+        warn("'bcast_numpy_array=True' is deprecated and will be unsupported"
+             " from December 2021", DeprecationWarning, stacklevel=2)
+
+        if _bcast_actx_array_type:
+            raise ValueError("'bcast_numpy_array' and '_bcast_actx_array_type'"
+                             " cannot be both set.")
+
     if rel_comparison and eq_comparison is None:
         eq_comparison = True
 
@@ -216,7 +225,7 @@ def with_container_arithmetic(
         raise TypeError("bcast_obj_array must be set if bcast_numpy_array is")
 
     if _bcast_actx_array_type is None:
-        if _cls_has_array_context_attr:
+        if _cls_has_array_context_attr and (not bcast_numpy_array):
             _bcast_actx_array_type = bcast_number
         else:
             _bcast_actx_array_type = False


### PR DESCRIPTION
```
Passing both 'bcast_numpy_array' and '_bcast_actx_array_types' was
ill-defined. For example, in the case of an ArrayContext whose thawed
array type is np.ndarray the specification would contradict between
broadcasting the argument numpy_array to return an object array *OR*
peforming the operation with every leaf array.

Consider the example below,

(
- 'Foo: ArrayContainer' whose arithmetic routines are
   generated by `with_container_arithmetic(bcast_numpy=True,
   _bcast_actx_array_types=True)`
- 'actx: ArrayContextT' for whom `np.ndarray` is a valid thawed array
   type.
)

Foo(DOFArray(actx, [38*actx.ones(3, np.float64)])) + np.array([3, 4, 5])
could be either of:
- array([Foo(DOFArray([array([41, 41, 41])])),
         Foo(DOFArray([array([42, 42, 42])])),
         Foo(DOFArray([array([43, 43, 43])]))]), OR,
- Foo(DOFArray(actx, array([41, 42, 43])))
```

Draft because
- [ ] https://github.com/ecisneros8/pyrometheus/pull/35
- [ ] https://github.com/illinois-ceesd/mirgecom/pull/514