### PR TITLE
Implements TaggableCLArray

### DIFF
--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -206,11 +206,7 @@ class PytatoPyOpenCLArrayContext(ArrayContext):
         return array.tagged(tags)
 
     def tag_axis(self, iaxis, tags: Union[Sequence[Tag], Tag], array):
-        # TODO
-        from warnings import warn
-        warn("tagging PytatoPyOpenCLArrayContext's array axes: not yet implemented",
-             stacklevel=2)
-        return array
+        return array.with_tagged_axis(iaxis, tags)
 
     def einsum(self, spec, *args, arg_names=None, tagged=()):
         import pyopencl.array as cla

--- a/arraycontext/impl/pytato/compile.py
+++ b/arraycontext/impl/pytato/compile.py
@@ -320,6 +320,7 @@ class CompiledFunction:
             representation.
         """
         from arraycontext.container.traversal import rec_keyed_map_array_container
+        from .utils import TaggableCLArray, to_tagged_cl_array
 
         input_kwargs_to_loopy = {}
 
@@ -332,7 +333,7 @@ class CompiledFunction:
             elif isinstance(arg, pt.array.DataWrapper):
                 # got a Datwwrapper => simply gets its data
                 arg = arg.data
-            elif isinstance(arg, cla.Array):
+            elif isinstance(arg, TaggableCLArray):
                 # got a frozen array  => do nothing
                 pass
             elif isinstance(arg, pt.Array):
@@ -354,7 +355,11 @@ class CompiledFunction:
         # }}}
 
         def to_output_template(keys, _):
-            return self.actx.thaw(out_dict[self.output_id_to_name_in_program[keys]])
+            # TODO: What should be done about the tags here?
+            return self.actx.thaw(to_tagged_cl_array(
+                out_dict[self.output_id_to_name_in_program[keys]],
+                None,
+                frozenset()))
 
         return rec_keyed_map_array_container(to_output_template,
                                              self.output_template)

--- a/arraycontext/impl/pytato/utils.py
+++ b/arraycontext/impl/pytato/utils.py
@@ -103,6 +103,7 @@ def to_tagged_cl_array(ary: cl_array.Array,
                            events=ary.events, _fast=True,
                            _context=ary.context,
                            _queue=ary.queue, _size=ary.size,
+                           axes=axes,
                            tags=tags)
 
 
@@ -133,6 +134,7 @@ class _DatawrapperToBoundPlaceholderMapper(CopyMapper):
                     shape=tuple(self.rec(s) if isinstance(s, Array) else s
                                 for s in expr.shape),
                     dtype=expr.dtype,
+                    axes=expr.axes,
                     tags=expr.tags)
 
     def map_size_param(self, expr: SizeParam) -> Array:

--- a/arraycontext/impl/pytato/utils.py
+++ b/arraycontext/impl/pytato/utils.py
@@ -23,11 +23,87 @@ THE SOFTWARE.
 """
 
 
-from typing import Any, Dict, Set, Tuple, Mapping
-from pytato.array import SizeParam, Placeholder, make_placeholder
+from typing import Any, Dict, Set, Tuple, Mapping, FrozenSet, Optional
+from pytato.array import SizeParam, Placeholder, make_placeholder, Axis
 from pytato.array import Array, DataWrapper, DictOfNamedArrays
 from pytato.transform import CopyMapper
 from pytools import UniqueNameGenerator
+from pytools.tag import Taggable, Tag
+import pyopencl.array as cl_array
+
+
+class TaggableCLArray(cl_array.Array, Taggable):
+    """
+    A :class:`cl_array.Array` that can be tagged.
+    """
+    def __init__(self, cq, shape, dtype, order="C", allocator=None,
+                 data=None, offset=0, strides=None, events=None, _flags=None,
+                 _fast=False, _size=None, _context=None, _queue=None,
+                 axes=None, tags=frozenset()):
+
+        super().__init__(cq=cq, shape=shape, dtype=dtype,
+                         order=order, allocator=allocator,
+                         data=data, offset=offset,
+                         strides=strides, events=events,
+                         _flags=_flags, _fast=_fast,
+                         _size=_size, _context=_context,
+                         _queue=_queue)
+
+        self.tags = tags
+        self.axes = axes
+
+    def copy(self, queue=cl_array._copy_queue, tags=None, axes=None):
+        if tags is not None or axes is not None:
+            if queue is not cl_array._copy_queue:
+                raise ValueError("Cannot change both 'tags'/'axes' and 'queue'"
+                                 " at once.")
+            tags = self.tags if tags is None else tags
+            axes = self.axes if axes is None else axes
+            return self.__class__(None, self.shape, self.dtype,
+                                  allocator=self.allocator,
+                                  strides=self.strides, data=self.base_data,
+                                  offset=self.offset, events=self.events,
+                                  _fast=True, _context=self.context,
+                                  _queue=self.queue, _size=self.size,
+                                  tags=tags, axes=axes)
+        else:
+            new_with_queue = super().copy(queue=queue)
+            return self.__class__(None, new_with_queue.shape,
+                                  new_with_queue.dtype,
+                                  allocator=new_with_queue.allocator,
+                                  strides=new_with_queue.strides,
+                                  data=new_with_queue.base_data,
+                                  offset=new_with_queue.offset,
+                                  events=new_with_queue.events, _fast=True,
+                                  _context=new_with_queue.context,
+                                  _queue=queue, _size=new_with_queue.size,
+                                  tags=new_with_queue.tags,
+                                  axes=new_with_queue.axes)
+
+
+def to_tagged_cl_array(ary: cl_array.Array,
+                       axes: Optional[Tuple[Axis, ...]],
+                       tags: FrozenSet[Tag]) -> TaggableCLArray:
+    """
+    Converts a *ary* to a :class:`TaggableCLArray` with *tags* attached to it.
+
+    :arg axes: An instance of :class:`pytato.Axis` for each dimension of the
+        array. If passed *None*, then initialized to a :class:`pytato.Axis`
+        with no tags attached for each dimension.
+    """
+    axes = axes if axes is not None else tuple(Axis(frozenset())
+                                               for _ in ary.shape)
+
+    return TaggableCLArray(None, ary.shape,
+                           ary.dtype,
+                           allocator=ary.allocator,
+                           strides=ary.strides,
+                           data=ary.base_data,
+                           offset=ary.offset,
+                           events=ary.events, _fast=True,
+                           _context=ary.context,
+                           _queue=ary.queue, _size=ary.size,
+                           tags=tags)
 
 
 class _DatawrapperToBoundPlaceholderMapper(CopyMapper):

--- a/test/test_pytato_arraycontext.py
+++ b/test/test_pytato_arraycontext.py
@@ -1,0 +1,90 @@
+""" PytatoArrayContext specific tests"""
+
+__copyright__ = "Copyright (C) 2021 University of Illinois Board of Trustees"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from arraycontext import (freeze, thaw, PytatoPyOpenCLArrayContext)
+from arraycontext import pytest_generate_tests_for_array_contexts
+from arraycontext.pytest import _PytestPytatoPyOpenCLArrayContextFactory
+from pytools.tag import Tag
+
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+# {{{ pytato-array context fixture
+
+class _PytatoPyOpenCLArrayContextForTests(PytatoPyOpenCLArrayContext):
+    """Like :class:`PytatoPyOpenCLArrayContext`, but applies no program
+    transformations whatsoever. Only to be used for testing internal to
+    :mod:`arraycontext`.
+    """
+
+    def transform_loopy_program(self, t_unit):
+        return t_unit
+
+
+class _PytatoPyOpenCLArrayContextForTestsFactory(
+        _PytestPytatoPyOpenCLArrayContextFactory):
+    actx_class = _PytatoPyOpenCLArrayContextForTests
+
+
+pytest_generate_tests = pytest_generate_tests_for_array_contexts([
+    _PytatoPyOpenCLArrayContextForTestsFactory,
+    ])
+
+# }}}
+
+
+# {{{ dummy tag types
+
+class FooTag(Tag):
+    """
+    Foo
+    """
+
+# }}}
+
+
+def test_tags_preserved_after_freeze(actx_factory):
+    from numpy.random import default_rng
+    rng = default_rng()
+
+    actx = actx_factory()
+    foo = thaw(freeze(actx
+                      .from_numpy(rng.random((10, 4)))
+                      .tagged(FooTag()),
+                      actx),
+               actx)
+    assert foo.tags_of_type(FooTag)
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        from pytest import main
+        main([__file__])
+
+# vim: fdm=marker


### PR DESCRIPTION
Converting to draft because #111, will soon make array axes taggable as well, which the `TaggableCLArray` should record as well.

- [ ] Must go after #111 