### PR TITLE
Allow scalars in to_numpy

### DIFF
--- a/arraycontext/impl/pyopencl/__init__.py
+++ b/arraycontext/impl/pyopencl/__init__.py
@@ -161,7 +161,7 @@ class PyOpenCLArrayContext(ArrayContext):
         return cl_array.to_device(self.queue, array, allocator=self.allocator)
 
     def to_numpy(self, array):
-        if not self._force_device_scalars and np.isscalar(array):
+        if np.isscalar(array):
             return array
 
         return array.get(queue=self.queue)

--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -105,6 +105,9 @@ class PytatoPyOpenCLArrayContext(ArrayContext):
         return pt.make_data_wrapper(cl_array)
 
     def to_numpy(self, array):
+        if np.isscalar(array):
+            return array
+
         cl_array = self.freeze(array)
         return cl_array.get(queue=self.queue)
 


### PR DESCRIPTION
These can show up when doing a [norm](https://github.com/inducer/arraycontext/blob/7bd2aa838724510e5d9638ad4c80c730022708e0/arraycontext/fake_numpy.py#L240-L241) or when a reduction happens on an empty array container of some sort. Then they require special handling everywhere for things like
```
actx.to_numpy(actx.np.linalg.norm(ary))
```