### PR TITLE
Fixes for dataclass_array_container

### DIFF
--- a/arraycontext/container/__init__.py
+++ b/arraycontext/container/__init__.py
@@ -173,9 +173,7 @@ def is_array_container_type(cls: type) -> bool:
         function will say that :class:`numpy.ndarray` is an array container
         type, only object arrays *actually are* array containers.
     """
-    assert isinstance(cls, type), \
-            f"must pass a type, not an instance: '{cls!r}'"
-    assert hasattr(cls, "__mro__"), "'cls' has no attribute '__mro__': "
+    assert isinstance(cls, type), f"must pass a {type!r}, not a '{cls!r}'"
 
     return (
             cls is ArrayContainer

--- a/arraycontext/container/__init__.py
+++ b/arraycontext/container/__init__.py
@@ -173,6 +173,10 @@ def is_array_container_type(cls: type) -> bool:
         function will say that :class:`numpy.ndarray` is an array container
         type, only object arrays *actually are* array containers.
     """
+    assert isinstance(cls, type), \
+            f"must pass a type, not an instance: '{cls!r}'"
+    assert hasattr(cls, "__mro__"), "'cls' has no attribute '__mro__': "
+
     return (
             cls is ArrayContainer
             or (serialize_container.dispatch(cls)

--- a/arraycontext/container/dataclass.py
+++ b/arraycontext/container/dataclass.py
@@ -46,10 +46,10 @@ def dataclass_array_container(cls: type) -> type:
     whether an attribute is an array container, the declared attribute type
     is checked by the criteria from :func:`is_array_container_type`.
     """
-    from dataclasses import is_dataclass
+    from dataclasses import is_dataclass, Field
     assert is_dataclass(cls)
 
-    def is_array_field(f):
+    def is_array_field(f: Field) -> bool:
         if __debug__:
             if not f.init:
                 raise ValueError(


### PR DESCRIPTION
There's a couple of random fixes to the dataclass helper in here:

1. Add an assert in `is_array_container_type` that `isinstance(cls, type)`. If a dataclass has an `Optional` or `Union` field (which aren't classes), `is_array_container_type` would raise some `AttributeError` anyway, but with a more cryptic message.

2. Added some checks in `dataclass_array_container` to give better error messages when it encounters unsuported field types: with `init=False`, string annotations or classes wrapped in `Optional` (or equivalent).