### PR TITLE
Use np.isscalar instead of isinstance(x, Number)

### DIFF
--- a/arraycontext/fake_numpy.py
+++ b/arraycontext/fake_numpy.py
@@ -147,8 +147,7 @@ class BaseFakeNumpyNamespace:
 
     def __getattr__(self, name):
         def loopy_implemented_elwise_func(*args):
-            from numbers import Number
-            if all(isinstance(ary, Number) for ary in args):
+            if all(np.isscalar(ary) for ary in args):
                 return getattr(np, name)(*args)
 
             actx = self._array_context
@@ -175,8 +174,7 @@ class BaseFakeNumpyNamespace:
             raise AttributeError(name)
 
     def _new_like(self, ary, alloc_like):
-        from numbers import Number
-        if isinstance(ary, Number):
+        if np.isscalar(ary):
             # NOTE: `np.zeros_like(x)` returns `array(x, shape=())`, which
             # is best implemented by concrete array contexts, if at all
             raise NotImplementedError("operation not implemented for scalars")
@@ -233,9 +231,7 @@ class BaseFakeNumpyLinalgNamespace:
         self._array_context = array_context
 
     def norm(self, ary, ord=None):
-        from numbers import Number
-
-        if isinstance(ary, Number):
+        if np.isscalar(ary):
             return abs(ary)
 
         actx = self._array_context
@@ -274,6 +270,7 @@ class BaseFakeNumpyLinalgNamespace:
         if ary.size == 0:
             return ary.dtype.type(0)
 
+        from numbers import Number
         if ord == 2:
             return actx.np.sqrt(actx.np.sum(abs(ary)**2))
         if ord == np.inf:


### PR DESCRIPTION
There's about a dozen places checking for scalars (from a quick grep) and these were the only ones using `isinstance(x, Number)`, so this should make it more consistent.