### PR TITLE
Wrap pytato's logical operations in fake numpy namespace

### DIFF
--- a/arraycontext/impl/pytato/fake_numpy.py
+++ b/arraycontext/impl/pytato/fake_numpy.py
@@ -142,8 +142,8 @@ class PytatoFakeNumpyNamespace(BaseFakeNumpyNamespace):
     def logical_or(self, x, y):
         return rec_multimap_array_container(pt.logical_or, x, y)
 
-    def logical_not(self, x, y):
-        return rec_multimap_array_container(pt.logical_not, x, y)
+    def logical_not(self, x):
+        return rec_multimap_array_container(pt.logical_not, x)
 
     def conj(self, x):
         return rec_multimap_array_container(pt.conj, x)

--- a/arraycontext/impl/pytato/fake_numpy.py
+++ b/arraycontext/impl/pytato/fake_numpy.py
@@ -136,6 +136,15 @@ class PytatoFakeNumpyNamespace(BaseFakeNumpyNamespace):
     def less_equal(self, x, y):
         return rec_multimap_array_container(pt.less_equal, x, y)
 
+    def logical_and(self, x, y):
+        return rec_multimap_array_container(pt.logical_and, x, y)
+
+    def logical_or(self, x, y):
+        return rec_multimap_array_container(pt.logical_or, x, y)
+
+    def logical_not(self, x, y):
+        return rec_multimap_array_container(pt.logical_not, x, y)
+
     def conj(self, x):
         return rec_multimap_array_container(pt.conj, x)
 


### PR DESCRIPTION
This small PR simply wraps the pytato logical operators and exposes them via the fake numpy namespace.