### PR TITLE
PytatoPyOpenCLArrayContext: always invoke MPMS materializer

### DIFF
--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -200,6 +200,10 @@ class PytatoPyOpenCLArrayContext(ArrayContext):
         :arg dag: An instance of :class:`pytato.DictOfNamedArrays`
         :returns: A transformed version of *dag*.
         """
+        import pytato as pt
+
+        dag = pt.transform.materialize_with_mpms(dag)
+
         return dag
 
     def tag(self, tags: Union[Sequence[Tag], Tag], array):


### PR DESCRIPTION
Suggested by @inducer in https://github.com/inducer/meshmode/pull/254#discussion_r756490536. It seems like a reasonable default that we try to cut down on the number of FlOps in the compiled kernel.