### PR TITLE
Fix type mismatch in serialize_container argument

### DIFF
--- a/arraycontext/container/__init__.py
+++ b/arraycontext/container/__init__.py
@@ -122,7 +122,7 @@ class NotAnArrayContainerError(TypeError):
 
 
 @singledispatch
-def serialize_container(ary: ArrayContainer) -> Iterable[Tuple[Any, Any]]:
+def serialize_container(ary: Any) -> Iterable[Tuple[Any, Any]]:
     r"""Serialize the array container into an iterable over its components.
 
     The order of the components and their identifiers are entirely under


### PR DESCRIPTION
Seems like the new version of mypy is looking into the `singledispatch` arguments a bit more closely. The issue was that
* the base `serialize_container` took an `ArrayContainer` (which is an actual class)
* the `ndarray` version took an `ndarray` (which is not a subclass of `ArrayContainer`!)

This just sets it to `Any` so that it's a proper fallback for all objects.

Fixes #130
