### PR TITLE
Avoid copy in flatten by not calling concatenate

### DIFF
--- a/arraycontext/container/traversal.py
+++ b/arraycontext/container/traversal.py
@@ -631,7 +631,10 @@ def flatten(ary: ArrayOrContainerT, actx: ArrayContext) -> Any:
 
     _flatten(ary)
 
-    return actx.np.concatenate(result)
+    if len(result) == 1:
+        return result[0]
+    else:
+        return actx.np.concatenate(result)
 
 
 def unflatten(


### PR DESCRIPTION
[cl.array.concatenate](https://github.com/inducer/pyopencl/blob/71b29745dc023a4d3aa9ddf22ff65c0cb3e6d703/pyopencl/array.py#L2654) seems to always create a copy, even if there's just one flat array (which seems to match `numpy`).

The `flatten` in meshmode returned the reshaped array without a copy if it could, so this can do that too, since it's a fairly common case.