### PR TITLE
Make `get_container_context_recursively` return actx or error

### DIFF
--- a/arraycontext/__init__.py
+++ b/arraycontext/__init__.py
@@ -40,7 +40,8 @@ from .metadata import _FirstAxisIsElementsTag
 from .container import (
         ArrayContainer, NotAnArrayContainerError,
         is_array_container, is_array_container_type,
-        get_container_context, get_container_context_recursively,
+        get_container_context_opt,
+        get_container_context_recursively, get_container_context_recursively_opt,
         serialize_container, deserialize_container,
         register_multivector_as_array_container)
 from .container.arithmetic import with_container_arithmetic
@@ -81,7 +82,9 @@ __all__ = (
 
         "ArrayContainer", "NotAnArrayContainerError",
         "is_array_container", "is_array_container_type",
-        "get_container_context", "get_container_context_recursively",
+        "get_container_context_opt",
+        "get_container_context_recursively_opt",
+        "get_container_context_recursively",
         "serialize_container", "deserialize_container",
         "register_multivector_as_array_container",
         "with_container_arithmetic",
@@ -122,6 +125,8 @@ def _deprecated_acf():
 
 
 _depr_name_to_replacement_and_obj = {
+        "get_container_context": ("get_container_context_opt",
+            get_container_context_opt),
         "FirstAxisIsElementsTag":
         ("meshmode.transform_metadata.FirstAxisIsElementsTag",
             _FirstAxisIsElementsTag),
@@ -145,6 +150,7 @@ if sys.version_info >= (3, 7):
 else:
     FirstAxisIsElementsTag = _FirstAxisIsElementsTag
     _acf = _deprecated_acf
+    get_container_context = get_container_context_opt
 
 # }}}
 

--- a/arraycontext/context.py
+++ b/arraycontext/context.py
@@ -39,7 +39,7 @@ Here are some rules of thumb to use when dealing with thawing and freezing:
 -   Note that array contexts need not necessarily be passed as a separate
     argument. Passing thawed data as an argument to a function suffices
     to supply an array context. The array context can be extracted from
-    a thawed argument using, e.g., :func:`~arraycontext.get_container_context`
+    a thawed argument using, e.g., :func:`~arraycontext.get_container_context_opt`
     or :func:`~arraycontext.get_container_context_recursively`.
 
 What does this mean concretely?

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -941,24 +941,25 @@ def test_container_freeze_thaw(actx_factory):
 
     # {{{ check
 
-    from arraycontext import get_container_context
-    from arraycontext import get_container_context_recursively
+    from arraycontext import (
+            get_container_context_opt,
+            get_container_context_recursively_opt)
 
-    assert get_container_context(ary_of_dofs) is None
-    assert get_container_context(mat_of_dofs) is None
-    assert get_container_context(ary_dof) is actx
-    assert get_container_context(dc_of_dofs) is actx
+    assert get_container_context_opt(ary_of_dofs) is None
+    assert get_container_context_opt(mat_of_dofs) is None
+    assert get_container_context_opt(ary_dof) is actx
+    assert get_container_context_opt(dc_of_dofs) is actx
 
-    assert get_container_context_recursively(ary_of_dofs) is actx
-    assert get_container_context_recursively(mat_of_dofs) is actx
+    assert get_container_context_recursively_opt(ary_of_dofs) is actx
+    assert get_container_context_recursively_opt(mat_of_dofs) is actx
 
     for ary in [ary_dof, ary_of_dofs, mat_of_dofs, dc_of_dofs]:
         frozen_ary = freeze(ary)
         thawed_ary = thaw(frozen_ary, actx)
         frozen_ary = freeze(thawed_ary)
 
-        assert get_container_context_recursively(frozen_ary) is None
-        assert get_container_context_recursively(thawed_ary) is actx
+        assert get_container_context_recursively_opt(frozen_ary) is None
+        assert get_container_context_recursively_opt(thawed_ary) is actx
 
     actx2 = actx.clone()
 


### PR DESCRIPTION
This is a deliberate compatibility break based on seeing code like this:

https://github.com/inducer/grudge/blob/62af257a45be631e2bf1d3c4cf9de4ec746f375d/grudge/trace_pair.py#L307

which clearly would not succeed if the return value was `None`, based on the notion that the original `get_container_context_recursively` is easy to misuse because of its `Optional` return value. The rest of this is  a renaming of `get_container_context` to `get_container_context_opt` for consistency.

As for the compatibility break, my justification is that all existing user code seems to be using the new `get_container_context_recursively` already. :)