### PR TITLE
Add `flat_size_and_dtype`

### DIFF
--- a/arraycontext/__init__.py
+++ b/arraycontext/__init__.py
@@ -59,7 +59,7 @@ from .container.traversal import (
         rec_map_reduce_array_container,
         rec_multimap_reduce_array_container,
         thaw, freeze,
-        flatten, unflatten,
+        flatten, unflatten, flat_size_and_dtype,
         from_numpy, to_numpy,
         outer)
 
@@ -97,7 +97,7 @@ __all__ = (
         "map_reduce_array_container", "multimap_reduce_array_container",
         "rec_map_reduce_array_container", "rec_multimap_reduce_array_container",
         "thaw", "freeze",
-        "flatten", "unflatten",
+        "flatten", "unflatten", "flat_size_and_dtype",
         "from_numpy", "to_numpy",
         "outer",
 

--- a/arraycontext/context.py
+++ b/arraycontext/context.py
@@ -334,7 +334,7 @@ class ArrayContext(ABC):
         return self.tag(tagged, out_ary)
 
     @abstractmethod
-    def clone(self):
+    def clone(self) -> "ArrayContext":
         """If possible, return a version of *self* that is semantically
         equivalent (i.e. implements all array operations in the same way)
         but is a separate object. May return *self* if that is not possible.


### PR DESCRIPTION
This is needed for buffer allocation in MPI communication in (multi-volume) grudge. Otherwise, the only way to find these metadata of a flattened buffer is to flatten it, which is a waste.

cc @majosm