### PR TITLE
Add typing to ArrayContext

### DIFF
--- a/arraycontext/container/traversal.py
+++ b/arraycontext/container/traversal.py
@@ -833,6 +833,9 @@ def to_numpy(ary: ArrayOrContainerT, actx: ArrayContext) -> Any:
     """
     def _to_numpy_with_check(subary: Any) -> Any:
         if isinstance(subary, actx.array_types) or np.isscalar(subary):
+            # NOTE: these are allowed by np.isscalar, but not here
+            assert not isinstance(subary, (str, bytes))
+
             return actx.to_numpy(subary)
         else:
             raise TypeError(

--- a/arraycontext/impl/pyopencl/__init__.py
+++ b/arraycontext/impl/pyopencl/__init__.py
@@ -29,11 +29,11 @@ THE SOFTWARE.
 """
 
 from warnings import warn
-from typing import Dict, List, Sequence, Optional, Union, TYPE_CHECKING
+from typing import Dict, List, Optional, Union, TYPE_CHECKING
 
 import numpy as np
 
-from pytools.tag import Tag
+from pytools.tag import ToTagSetConvertible
 
 from arraycontext.context import ArrayContext, _ScalarLike
 from arraycontext.container.traversal import rec_map_array_container
@@ -301,7 +301,7 @@ class PyOpenCLArrayContext(ArrayContext):
 
         return t_unit
 
-    def tag(self, tags: Union[Sequence[Tag], Tag], array):
+    def tag(self, tags: ToTagSetConvertible, array):
         import pyopencl.array as cl_array
         from arraycontext.impl.pyopencl.taggable_cl_array import (TaggableCLArray,
                                                                   to_tagged_cl_array)
@@ -317,7 +317,7 @@ class PyOpenCLArrayContext(ArrayContext):
 
         return rec_map_array_container(_rec_tagged, array)
 
-    def tag_axis(self, iaxis, tags: Union[Sequence[Tag], Tag], array):
+    def tag_axis(self, iaxis, tags: ToTagSetConvertible, array):
         import pyopencl.array as cl_array
         from arraycontext.impl.pyopencl.taggable_cl_array import (TaggableCLArray,
                                                                   to_tagged_cl_array)

--- a/arraycontext/impl/pyopencl/taggable_cl_array.py
+++ b/arraycontext/impl/pyopencl/taggable_cl_array.py
@@ -7,7 +7,7 @@
 
 import pyopencl.array as cla
 from typing import Any, Dict, FrozenSet, Optional, Tuple
-from pytools.tag import Taggable, Tag, TagsType, TagOrIterableType
+from pytools.tag import Taggable, Tag, ToTagSetConvertible
 from dataclasses import dataclass
 from pytools import memoize
 
@@ -93,12 +93,12 @@ class TaggableCLArray(cla.Array, Taggable):
         return type(self)(None, tags=self.tags, axes=self.axes,
                           **_unwrap_cl_array(ary))
 
-    def _with_new_tags(self, tags: TagsType) -> "TaggableCLArray":
+    def _with_new_tags(self, tags: FrozenSet[Tag]) -> "TaggableCLArray":
         return type(self)(None, tags=tags, axes=self.axes,
                           **_unwrap_cl_array(self))
 
     def with_tagged_axis(self, iaxis: int,
-                         tags: TagOrIterableType) -> "TaggableCLArray":
+                         tags: ToTagSetConvertible) -> "TaggableCLArray":
         """
         Returns a copy of *self* with *iaxis*-th axis tagged with *tags*.
         """

--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -44,8 +44,8 @@ THE SOFTWARE.
 from arraycontext.context import ArrayContext, _ScalarLike
 from arraycontext.container.traversal import rec_map_array_container
 import numpy as np
-from typing import Any, Callable, Union, Sequence, TYPE_CHECKING
-from pytools.tag import Tag
+from typing import Any, Callable, Union, TYPE_CHECKING
+from pytools.tag import ToTagSetConvertible
 
 if TYPE_CHECKING:
     import pytato
@@ -262,14 +262,14 @@ class PytatoPyOpenCLArrayContext(ArrayContext):
 
         return dag
 
-    def tag(self, tags: Union[Sequence[Tag], Tag], array):
+    def tag(self, tags: ToTagSetConvertible, array):
         return rec_map_array_container(lambda x: x.tagged(tags),
                                        array)
 
-    def tag_axis(self, iaxis, tags: Union[Sequence[Tag], Tag], array):
-        return rec_map_array_container(lambda x: x.with_tagged_axis(iaxis,
-                                                                     tags),
-                                        array)
+    def tag_axis(self, iaxis, tags: ToTagSetConvertible, array):
+        return rec_map_array_container(
+            lambda x: x.with_tagged_axis(iaxis, tags),
+            array)
 
     def einsum(self, spec, *args, arg_names=None, tagged=()):
         import pyopencl.array as cla

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def main():
             "numpy",
 
             # https://github.com/inducer/arraycontext/pull/147
-            "pytools>=2022.1.1",
+            "pytools>=2022.1.3",
 
             "pytest>=2.3",
             "loopy>=2019.1",


### PR DESCRIPTION
This uses the new `Array` and `Scalar` protocols to add some type annotations to `ArrayContext`.

What other places did you have in mind in https://github.com/inducer/arraycontext/pull/153#discussion_r843365012? I looked a bit through the container stuff, but they're all nested, so there aren't many places where it makes sense to use these.