### PR TITLE
`with_container_arithmetic`: Default cls_has_array_context_attr based on presence of attribute

### DIFF
--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -672,36 +672,44 @@ def test_array_context_einsum_array_tripleprod(actx_factory, spec):
 # {{{ array container classes for test
 
 @with_container_arithmetic(bcast_obj_array=False,
-        eq_comparison=False, rel_comparison=False)
+        eq_comparison=False, rel_comparison=False,
+        _cls_has_array_context_attr=True)
 @dataclass_array_container
 @dataclass(frozen=True)
 class MyContainer:
     name: str
-    mass: DOFArray
+    mass: DOFArray   # or np.ndarray
     momentum: np.ndarray
-    enthalpy: DOFArray
+    enthalpy: DOFArray   # or np.ndarray
 
     @property
     def array_context(self):
-        return self.mass.array_context
+        if isinstance(self.mass, np.ndarray):
+            return next(iter(self.mass)).array_context
+        else:
+            return self.mass.array_context
 
 
 @with_container_arithmetic(
         bcast_obj_array=False,
         bcast_container_types=(DOFArray, np.ndarray),
         matmul=True,
-        rel_comparison=True,)
+        rel_comparison=True,
+        _cls_has_array_context_attr=True)
 @dataclass_array_container
 @dataclass(frozen=True)
 class MyContainerDOFBcast:
     name: str
-    mass: DOFArray
+    mass: DOFArray  # or np.ndarray
     momentum: np.ndarray
-    enthalpy: DOFArray
+    enthalpy: DOFArray  # or np.ndarray
 
     @property
     def array_context(self):
-        return self.mass.array_context
+        if isinstance(self.mass, np.ndarray):
+            return next(iter(self.mass)).array_context
+        else:
+            return self.mass.array_context
 
 
 def _get_test_containers(actx, ambient_dim=2, shapes=50_000):


### PR DESCRIPTION
I think it makes sense for `WaveState * pytato.Array` to just work, but currently it won't, because `with_container_arithmetic` will only access `.array_context` on a container (to get the array types) if `_cls_has_array_context_attr` is set to `True`. Just defaulting it to True if the attribute exists also doesn't work, because many of those properties are implemented like this:
https://github.com/inducer/arraycontext/blob/b75ba4f60c601664edc495cc3606fc9f7e47866b/test/test_arraycontext.py#L684-L686=
but are then used with numpy arrays in the `.mass` attribute, where that implementation will fail.

*If* a class has the `.array_context` attribute, the code in this PR tries harder to get a hold of the array context involved, ultimately nudging people to fix their `.array_context` property implementations and passing `_cls_has_array_context_attr=True` (which we may then deprecate even further into the future, using just existence of the attribute instead).