### PR TITLE
PytatoArrayContext.freeze: support container freezes

### DIFF
--- a/arraycontext/__init__.py
+++ b/arraycontext/__init__.py
@@ -61,7 +61,7 @@ from .container.traversal import (
         thaw, freeze,
         flatten, unflatten, flat_size_and_dtype,
         from_numpy, to_numpy,
-        outer)
+        outer, with_array_context)
 
 from .impl.pyopencl import PyOpenCLArrayContext
 from .impl.pytato import (PytatoPyOpenCLArrayContext,
@@ -101,7 +101,7 @@ __all__ = (
         "rec_map_reduce_array_container", "rec_multimap_reduce_array_container",
         "thaw", "freeze",
         "flatten", "unflatten", "flat_size_and_dtype",
-        "from_numpy", "to_numpy",
+        "from_numpy", "to_numpy", "with_array_context",
         "outer",
 
         "PyOpenCLArrayContext", "PytatoPyOpenCLArrayContext",

--- a/arraycontext/container/traversal.py
+++ b/arraycontext/container/traversal.py
@@ -880,7 +880,10 @@ def to_numpy(ary: ArrayOrContainerT, actx: ArrayContext) -> Any:
                     f"array of type '{type(subary).__name__}' not in "
                     f"supported types {actx.array_types}")
 
-    return rec_map_array_container(_to_numpy_with_check, ary)
+    return rec_map_array_container(_to_numpy_with_check,
+                                   # do a freeze first, if 'actx' supports
+                                   # container-wide freezes
+                                   thaw(freeze(ary, actx), actx))
 
 # }}}
 


### PR DESCRIPTION
Freezing across containers can potentially re-use common sub-expressions.

- :warning: Needs to go in conjunction with https://github.com/inducer/meshmode/pull/327.

Draft because:
- [x] Pass CI by correctly pointing the meshmode branch in the downstream CI.
- [x] DROP final commit before merge