### PR TITLE
Deprecate empty / empty_like / zeros_like

### DIFF
--- a/arraycontext/context.py
+++ b/arraycontext/context.py
@@ -299,9 +299,19 @@ class ArrayContext(ABC):
         pass
 
     def empty_like(self, ary: Array) -> Array:
+        from warnings import warn
+        warn(f"{type(self).__name__}.empty_like is deprecated and will stop "
+            "working in 2023. Prefer actx.np.zeros_like instead.",
+            DeprecationWarning, stacklevel=2)
+
         return self.empty(shape=ary.shape, dtype=ary.dtype)
 
     def zeros_like(self, ary: Array) -> Array:
+        from warnings import warn
+        warn(f"{type(self).__name__}.zeros_like is deprecated and will stop "
+            "working in 2023. Use actx.np.zeros_like instead.",
+            DeprecationWarning, stacklevel=2)
+
         return self.zeros(shape=ary.shape, dtype=ary.dtype)
 
     @abstractmethod

--- a/arraycontext/fake_numpy.py
+++ b/arraycontext/fake_numpy.py
@@ -91,12 +91,6 @@ class BaseFakeNumpyNamespace:
         # "interp",
         })
 
-    def empty_like(self, ary):
-        return self._array_context.empty_like(ary)
-
-    def zeros_like(self, ary):
-        return self._array_context.zeros_like(ary)
-
     def conjugate(self, x):
         # NOTE: conjugate distributes over object arrays, but it looks for a
         # `conjugate` ufunc, while some implementations only have the shorter

--- a/arraycontext/impl/jax/__init__.py
+++ b/arraycontext/impl/jax/__init__.py
@@ -88,6 +88,11 @@ class EagerJAXArrayContext(ArrayContext):
     # {{{ ArrayContext interface
 
     def empty(self, shape, dtype):
+        from warnings import warn
+        warn(f"{type(self).__name__}.empty is deprecated and will stop "
+            "working in 2023. Prefer actx.zeros instead.",
+            DeprecationWarning, stacklevel=2)
+
         import jax.numpy as jnp
         return jnp.empty(shape=shape, dtype=dtype)
 
@@ -96,16 +101,23 @@ class EagerJAXArrayContext(ArrayContext):
         return jnp.zeros(shape=shape, dtype=dtype)
 
     def empty_like(self, ary):
+        from warnings import warn
+        warn(f"{type(self).__name__}.empty_like is deprecated and will stop "
+            "working in 2023. Prefer actx.np.zeros_like instead.",
+            DeprecationWarning, stacklevel=2)
+
         def _empty_like(array):
             return self.empty(array.shape, array.dtype)
 
         return self._rec_map_container(_empty_like, ary)
 
     def zeros_like(self, ary):
-        def _zeros_like(array):
-            return self.zeros(array.shape, array.dtype)
+        from warnings import warn
+        warn(f"{type(self).__name__}.zeros_like is deprecated and will stop "
+            "working in 2023. Use actx.np.zeros_like instead.",
+            DeprecationWarning, stacklevel=2)
 
-        return self._rec_map_container(_zeros_like, ary, default_scalar=0)
+        return self.np.zeros_like(ary)
 
     def from_numpy(self, array):
         def _from_numpy(ary):

--- a/arraycontext/impl/jax/fake_numpy.py
+++ b/arraycontext/impl/jax/fake_numpy.py
@@ -56,6 +56,25 @@ class EagerJAXFakeNumpyNamespace(BaseFakeNumpyNamespace):
 
     # {{{ array creation routines
 
+    def empty_like(self, ary):
+        from warnings import warn
+        warn(f"{type(self._array_context).__name__}.np.empty_like is "
+            "deprecated and will stop working in 2023. Prefer actx.np.zeros_like "
+            "instead.",
+            DeprecationWarning, stacklevel=2)
+
+        def _empty_like(array):
+            return self._array_context.empty(array.shape, array.dtype)
+
+        return self._array_context._rec_map_container(_empty_like, ary)
+
+    def zeros_like(self, ary):
+        def _zeros_like(array):
+            return self._array_context.zeros(array.shape, array.dtype)
+
+        return self._array_context._rec_map_container(
+            _zeros_like, ary, default_scalar=0)
+
     def ones_like(self, ary):
         return self.full_like(ary, 1)
 

--- a/arraycontext/impl/pyopencl/__init__.py
+++ b/arraycontext/impl/pyopencl/__init__.py
@@ -189,6 +189,11 @@ class PyOpenCLArrayContext(ArrayContext):
     # {{{ ArrayContext interface
 
     def empty(self, shape, dtype):
+        from warnings import warn
+        warn(f"{type(self).__name__}.empty is deprecated and will stop "
+            "working in 2023. Prefer actx.zeros instead.",
+            DeprecationWarning, stacklevel=2)
+
         import arraycontext.impl.pyopencl.taggable_cl_array as tga
         return tga.empty(self.queue, shape, dtype, allocator=self.allocator)
 
@@ -197,6 +202,11 @@ class PyOpenCLArrayContext(ArrayContext):
         return tga.zeros(self.queue, shape, dtype, allocator=self.allocator)
 
     def empty_like(self, ary):
+        from warnings import warn
+        warn(f"{type(self).__name__}.empty_like is deprecated and will stop "
+            "working in 2023. Prefer actx.np.zeros_like instead.",
+            DeprecationWarning, stacklevel=2)
+
         import arraycontext.impl.pyopencl.taggable_cl_array as tga
 
         def _empty_like(array):
@@ -206,13 +216,12 @@ class PyOpenCLArrayContext(ArrayContext):
         return self._rec_map_container(_empty_like, ary)
 
     def zeros_like(self, ary):
-        import arraycontext.impl.pyopencl.taggable_cl_array as tga
+        from warnings import warn
+        warn(f"{type(self).__name__}.zeros_like is deprecated and will stop "
+            "working in 2023. Use actx.np.zeros_like instead.",
+            DeprecationWarning, stacklevel=2)
 
-        def _zeros_like(array):
-            return tga.zeros(self.queue, array.shape, array.dtype,
-                allocator=self.allocator, axes=array.axes, tags=array.tags)
-
-        return self._rec_map_container(_zeros_like, ary, default_scalar=0)
+        return self.np.zeros_like(ary)
 
     def from_numpy(self, array):
         import arraycontext.impl.pyopencl.taggable_cl_array as tga

--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -348,10 +348,12 @@ class PytatoPyOpenCLArrayContext(_BasePytatoArrayContext):
     # {{{ ArrayContext interface
 
     def zeros_like(self, ary):
-        def _zeros_like(array):
-            return self.zeros(array.shape, array.dtype)
+        from warnings import warn
+        warn(f"{type(self).__name__}.zeros_like is deprecated and will stop "
+            "working in 2023. Use actx.np.zeros_like instead.",
+            DeprecationWarning, stacklevel=2)
 
-        return self._rec_map_container(_zeros_like, ary, default_scalar=0)
+        return self.np.zeros_like(ary)
 
     def from_numpy(self, array):
         import pytato as pt
@@ -720,10 +722,12 @@ class PytatoJAXArrayContext(_BasePytatoArrayContext):
     # {{{ ArrayContext interface
 
     def zeros_like(self, ary):
-        def _zeros_like(array):
-            return self.zeros(array.shape, array.dtype)
+        from warnings import warn
+        warn(f"{type(self).__name__}.zeros_like is deprecated and will stop "
+            "working in 2023. Use actx.np.zeros_like instead.",
+            DeprecationWarning, stacklevel=2)
 
-        return self._rec_map_container(_zeros_like, ary, default_scalar=0)
+        return self.np.zeros_like(ary)
 
     def from_numpy(self, array):
         import jax

--- a/arraycontext/impl/pytato/fake_numpy.py
+++ b/arraycontext/impl/pytato/fake_numpy.py
@@ -76,6 +76,13 @@ class PytatoFakeNumpyNamespace(LoopyBasedFakeNumpyNamespace):
 
     # {{{ array creation routines
 
+    def zeros_like(self, ary):
+        def _zeros_like(array):
+            return self._array_context.zeros(array.shape, array.dtype)
+
+        return self._array_context._rec_map_container(
+            _zeros_like, ary, default_scalar=0)
+
     def ones_like(self, ary):
         return self.full_like(ary, 1)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,39 @@ implementations for:
 :mod:`arraycontext` started life as an array abstraction for use with the
 :mod:`meshmode` unstrucuted discretization package.
 
+Design Guidelines
+-----------------
+
+Here are some of the guidelines we aim to follow in :mod:`arraycontext`. There
+exist numerous other, related efforts, such as the `Python array API standard
+<https://data-apis.org/array-api/latest/purpose_and_scope.html>`__. These
+points may aid in clarifying and differentiating our objectives.
+
+- The array context is about exposing the common subset of operations
+  available in immutable and mutable arrays. As a result, the interface
+  does *not* seek to support interfaces that provide, enable, or are typically
+  used only with in-place mutation.
+
+  For example: The equivalents of :func:`numpy.empty` were deprecated
+  and will eventually be removed.
+
+- Each array context offers a specific subset of of :mod:`numpy` under
+  :attr:`arraycontext.ArrayContext.np`. Functions under this namespace
+  must be unconditionally :mod:`numpy`-compatible, that is, they may not
+  offer an interface beyond what numpy offers. Functions that are
+  incompatible, for example by supporting tag metadata
+  (cf. :meth:`arraycontext.ArrayContext.einsum`) should live under the
+  :class:`~arraycontext.ArrayContext` directly.
+
+- Similarly, we strive to minimize redundancy between attributes of
+  :class:`~arraycontext.ArrayContext` and :attr:`arraycontext.ArrayContext.np`.
+
+  For example: ``ArrayContext.empty_like`` was deprecated.
+
+- Array containers are data structures that may contain arrays.
+  See :mod:`arraycontext.container`. We strive to support these, where sensible,
+  in :class:`~arraycontext.ArrayContext` and :attr:`arraycontext.ArrayContext.np`.
+
 Contents
 --------
 


### PR DESCRIPTION
As discussed in #178, this
* deprecates `empty` and `empty_like`.
* deprecates `actx.np.empty_like` for the contexts that supported that.
* deprecates `actx.zeros_like` in favor of `actx.np.zeros_like`.