### PR TITLE
PytatoPyOpenCLArrayContext: use SVM allocator if available, limit arg size for GPUs

### DIFF
--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -204,6 +204,9 @@ class _BasePytatoArrayContext(ArrayContext, abc.ABC):
     def permits_advanced_indexing(self):
         return True
 
+    def get_target(self):
+        return None
+
     # }}}
 
 # }}}

--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -54,6 +54,7 @@ from arraycontext.context import ArrayContext, Array, ArrayOrContainer, ScalarLi
 from arraycontext.container.traversal import (rec_map_array_container,
                                               with_array_context)
 from arraycontext.metadata import NameHint
+from pytools import memoize_method
 
 if TYPE_CHECKING:
     import pytato
@@ -321,6 +322,7 @@ class PytatoPyOpenCLArrayContext(_BasePytatoArrayContext):
             self._rec_map_container(_to_numpy, self.freeze(array)),
             actx=None)
 
+    @memoize_method
     def get_target(self):
         import pyopencl as cl
         from pytato.target.loopy import LoopyPyOpenCLTarget

--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -232,7 +232,7 @@ class PytatoLoopyPyOpenCLTarget(LoopyPyOpenCLTarget):
 
             from loopy import PyOpenCLTarget
             target = PyOpenCLTarget(
-                            limit_arg_size_nbytes=42)
+                            limit_arg_size_nbytes=self.dev.max_parameter_size)
 
         return target
 

--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -260,7 +260,6 @@ class PytatoPyOpenCLArrayContext(_BasePytatoArrayContext):
     def __init__(
             self, queue: "cl.CommandQueue", allocator=None, *,
             use_memory_pool: Optional[bool] = None,
-            allocator_uses_svm: Optional[bool] = None,
             compile_trace_callback: Optional[Callable[[Any, str, Any], None]] = None
             ) -> None:
         """

--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -59,6 +59,7 @@ from pytools import memoize_method
 if TYPE_CHECKING:
     import pytato
     import pyopencl as cl
+    import loopy as lp
 
 if getattr(sys, "_BUILDING_SPHINX_DOCS", False):
     import pyopencl as cl  # noqa: F811
@@ -218,13 +219,13 @@ from pytato.target.loopy import LoopyPyOpenCLTarget
 
 
 class PytatoLoopyPyOpenCLTarget(LoopyPyOpenCLTarget):
-    def __init__(self, dev, using_svm) -> None:
+    def __init__(self, dev: "cl.Device", using_svm: bool) -> None:
         super().__init__()
         self.dev = dev
         self.using_svm = using_svm
 
     @memoize_method
-    def get_loopy_target(self):
+    def get_loopy_target(self) -> Optional["lp.PyOpenCLTarget"]:
         import pyopencl as cl
         target = None
         if (self.using_svm and self.dev.type & cl.device_type.GPU

--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -65,6 +65,10 @@ if getattr(sys, "_BUILDING_SPHINX_DOCS", False):
     import pyopencl as cl  # noqa: F811
 
 
+import logging
+logger = logging.getLogger(__name__)
+
+
 # {{{ tag conversion
 
 def _preprocess_array_tags(tags: ToTagSetConvertible) -> FrozenSet[Tag]:
@@ -231,9 +235,11 @@ class PytatoLoopyPyOpenCLTarget(LoopyPyOpenCLTarget):
         if (self.using_svm and self.dev.type & cl.device_type.GPU
                 and cl.characterize.has_coarse_grain_buffer_svm(self.dev)):
 
+            limit = self.dev.max_parameter_size
+            logger.info(f"PytatoLoopyPyOpenCLTarget: limit_arg_size_nbytes={limit}")
+
             from loopy import PyOpenCLTarget
-            target = PyOpenCLTarget(
-                            limit_arg_size_nbytes=self.dev.max_parameter_size)
+            target = PyOpenCLTarget(limit_arg_size_nbytes=limit)
 
         return target
 

--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -229,6 +229,7 @@ class _ArgSizeLimitingPytatoLoopyPyOpenCLTarget(LoopyPyOpenCLTarget):
 
     @memoize_method
     def get_loopy_target(self) -> Optional["lp.PyOpenCLTarget"]:
+        from loopy import PyOpenCLTarget
         return PyOpenCLTarget(limit_arg_size_nbytes=self.limit_arg_size_nbytes)
 
 

--- a/arraycontext/impl/pytato/compile.py
+++ b/arraycontext/impl/pytato/compile.py
@@ -417,9 +417,9 @@ class LazilyPyOpenCLCompilingFunctionCaller(BaseLazilyCompilingFunctionCaller):
         with ProcessLogger(logger, f"generate_loopy for '{prg_id}'"):
             import pyopencl as cl
             dev = self.actx.context.devices[0]
-            limit = dev.max_parameter_size
             target = None
             if dev.type & cl.device_type.GPU:
+                limit = dev.max_parameter_size
                 # Leave some extra space since our sizes are estimates
                 target = lp.PyOpenCLTarget(limit_arg_size_nbytes=limit//2)
 

--- a/arraycontext/impl/pytato/compile.py
+++ b/arraycontext/impl/pytato/compile.py
@@ -418,7 +418,8 @@ class LazilyPyOpenCLCompilingFunctionCaller(BaseLazilyCompilingFunctionCaller):
             import pyopencl as cl
             dev = self.actx.context.devices[0]
             target = None
-            if dev.type & cl.device_type.GPU:
+            if (dev.type & cl.device_type.GPU
+                    and cl.characterize.has_coarse_grain_buffer_svm(dev)):
                 limit = dev.max_parameter_size
                 # Leave some extra space since our sizes are estimates
                 target = lp.PyOpenCLTarget(limit_arg_size_nbytes=limit//2)

--- a/arraycontext/impl/pytato/compile.py
+++ b/arraycontext/impl/pytato/compile.py
@@ -415,22 +415,13 @@ class LazilyPyOpenCLCompilingFunctionCaller(BaseLazilyCompilingFunctionCaller):
                 prg_id, "pre_generate_loopy", pt_dict_of_named_arrays)
 
         with ProcessLogger(logger, f"generate_loopy for '{prg_id}'"):
-            import pyopencl as cl
-            dev = self.actx.context.devices[0]
-            target = None
-            if (dev.type & cl.device_type.GPU
-                    and cl.characterize.has_coarse_grain_buffer_svm(dev)):
-                limit = dev.max_parameter_size
-                # Leave some extra space since our sizes are estimates
-                target = lp.PyOpenCLTarget(limit_arg_size_nbytes=limit//2)
-
             pytato_program = pt.generate_loopy(
                     pt_dict_of_named_arrays,
                     options=lp.Options(
                         return_dict=True,
                         no_numpy=True),
                     function_name=_prg_id_to_kernel_name(prg_id),
-                    target=target,
+                    target=self.actx.get_target(),
                     )
             assert isinstance(pytato_program, BoundPyOpenCLProgram)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ git+https://github.com/inducer/pymbolic.git#egg=pymbolic
 git+https://github.com/inducer/pyopencl.git#egg=pyopencl
 git+https://github.com/inducer/islpy.git#egg=islpy
 
-git+https://github.com/inducer/loopy.git@svm-args#egg=loopy
+git+https://github.com/inducer/loopy.git#egg=loopy
 git+https://github.com/inducer/pytato.git@limit_arg_size#egg=pytato

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ git+https://github.com/inducer/pymbolic.git#egg=pymbolic
 git+https://github.com/inducer/pyopencl.git#egg=pyopencl
 git+https://github.com/inducer/islpy.git#egg=islpy
 
-git+https://github.com/inducer/loopy.git#egg=loopy
-git+https://github.com/inducer/pytato.git#egg=pytato
+git+https://github.com/inducer/loopy.git@svm-args#egg=loopy
+git+https://github.com/inducer/pytato.git@limit_arg_size#egg=pytato

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ git+https://github.com/inducer/pyopencl.git#egg=pyopencl
 git+https://github.com/inducer/islpy.git#egg=islpy
 
 git+https://github.com/inducer/loopy.git#egg=loopy
-git+https://github.com/inducer/pytato.git@limit_arg_size#egg=pytato
+git+https://github.com/inducer/pytato.git#egg=pytato

--- a/test/test_pytato_arraycontext.py
+++ b/test/test_pytato_arraycontext.py
@@ -100,6 +100,27 @@ def test_tags_preserved_after_freeze(actx_factory):
     assert foo.axes[1].tags_of_type(BazTag)
 
 
+def test_arg_size_limit(actx_factory):
+    ran_callback = False
+
+    def my_ctc(what, stage, ir):
+        if stage == "final":
+            assert ir.target.limit_arg_size_nbytes == 42
+            nonlocal ran_callback
+            ran_callback = True
+
+    def twice(x):
+        return 2 * x
+
+    actx = _PytatoPyOpenCLArrayContextForTests(
+        actx_factory().queue, compile_trace_callback=my_ctc, _force_svm_arg_limit=42)
+
+    f = actx.compile(twice)
+    f(99)
+
+    assert ran_callback
+
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:


### PR DESCRIPTION
Needs:

- ~~https://github.com/inducer/pytato/pull/359~~ (maybe not needed)
- ~~https://github.com/inducer/loopy/pull/642~~