### PR TITLE
Rename AllocatorInterface to AllocatorBase

### DIFF
--- a/arraycontext/impl/pyopencl/__init__.py
+++ b/arraycontext/impl/pyopencl/__init__.py
@@ -74,7 +74,7 @@ class PyOpenCLArrayContext(ArrayContext):
 
     def __init__(self,
             queue: "pyopencl.CommandQueue",
-            allocator: Optional["pyopencl.tools.AllocatorInterface"] = None,
+            allocator: Optional["pyopencl.tools.AllocatorBase"] = None,
             wait_event_queue_length: Optional[int] = None,
             force_device_scalars: bool = False) -> None:
         r"""


### PR DESCRIPTION
Should fix the docs
https://github.com/inducer/boxtree/runs/8283995087?check_suite_focus=true