### PR TITLE
PytatoPyOpenCLArrayContext: don't trust the arg limit reported by the GPU

### DIFF
--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -388,15 +388,19 @@ class PytatoPyOpenCLArrayContext(_BasePytatoArrayContext):
                     and cl_char.has_coarse_grain_buffer_svm(dev))):
 
             if dev.max_parameter_size == 4352:
-                # Nvidia devices and PTXAS advertise a limit of 4352 bytes,
+                # Nvidia devices and PTXAS declare a limit of 4352 bytes,
                 # which is incorrect. The CUDA documentation at
                 # https://docs.nvidia.com/cuda/cuda-c-programming-guide/#function-parameters
-                # advertises a limit of 4KB, which is also incorrect.
+                # mentions a limit of 4KB, which is also incorrect.
                 # As far as I can tell, the actual limit is around 4080
                 # bytes, at least on a K40. Reducing the limit further
-                # in order ot be on the safe side.
+                # in order to be on the safe side.
 
                 limit = 4096-200
+
+                from warnings import warn
+                warn("Running on an Nvidia GPU, reducing the argument "
+                    f"size limit from 4352 to {limit}.")
             else:
                 limit = dev.max_parameter_size
 

--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -396,6 +396,10 @@ class PytatoPyOpenCLArrayContext(_BasePytatoArrayContext):
                 # bytes, at least on a K40. Reducing the limit further
                 # in order to be on the safe side.
 
+                # Note that the naming convention isn't super consistent
+                # for Nvidia GPUs, so that we only use the maximum
+                # parameter size to determine if it is an Nvidia GPU.
+
                 limit = 4096-200
 
                 from warnings import warn

--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -402,7 +402,7 @@ class PytatoPyOpenCLArrayContext(_BasePytatoArrayContext):
                     self.using_svm and dev.type & cl.device_type.GPU
                     and cl_char.has_coarse_grain_buffer_svm(dev))):
 
-            limit = dev.max_parameter_size
+            limit = dev.max_parameter_size // 2
             if self._force_svm_arg_limit is not None:
                 limit = self._force_svm_arg_limit
 

--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -387,7 +387,19 @@ class PytatoPyOpenCLArrayContext(_BasePytatoArrayContext):
                     self.using_svm and dev.type & cl.device_type.GPU
                     and cl_char.has_coarse_grain_buffer_svm(dev))):
 
-            limit = dev.max_parameter_size // 2
+            if dev.max_parameter_size == 4352:
+                # Nvidia devices and PTXAS advertise a limit of 4352 bytes,
+                # which is incorrect. The CUDA documentation at
+                # https://docs.nvidia.com/cuda/cuda-c-programming-guide/#function-parameters
+                # advertises a limit of 4KB, which is also incorrect.
+                # As far as I can tell, the actual limit is around 4080
+                # bytes, at least on a K40. Reducing the limit further
+                # in order ot be on the safe side.
+
+                limit = 4096-200
+            else:
+                limit = dev.max_parameter_size
+
             if self._force_svm_arg_limit is not None:
                 limit = self._force_svm_arg_limit
 


### PR DESCRIPTION
Apparently, CUDA doesn't like it when argument sizes get close to the reported limit.

Avoids PTX/JIT errors of the type:
CUDA_ERROR_INVALID_IMAGE: device kernel image is invalid
CUDA_ERROR_FILE_NOT_FOUND: file not found

Partially addresses https://github.com/illinois-ceesd/mirgecom/issues/679