### PR TITLE
pytato.compile: do not assume that the callable will be named

### DIFF
--- a/arraycontext/impl/pytato/compile.py
+++ b/arraycontext/impl/pytato/compile.py
@@ -58,7 +58,7 @@ def _to_identifier(s: str) -> str:
 
 def _prg_id_to_kernel_name(f: Any) -> str:
     if callable(f):
-        name = f.__name__
+        name = getattr(f, "__name__", "<anonymous>")
         if not name.isidentifier():
             return "actx_compiled_" + _to_identifier(name)
         else:

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -1574,6 +1574,20 @@ def test_tagging(actx_factory):
     assert not ary.axes[1].tags_of_type(ExampleTag)
 
 
+def test_compile_anonymous_function(actx_factory):
+    from functools import partial
+    # See https://github.com/inducer/grudge/issues/287
+    actx = actx_factory()
+    f = actx.compile(lambda x: 2*x+40)
+    np.testing.assert_allclose(
+        actx.to_numpy(f(1+actx.zeros((10, 4), "float64"))),
+        42)
+    f = actx.compile(partial(lambda x: 2*x+40))
+    np.testing.assert_allclose(
+        actx.to_numpy(f(1+actx.zeros((10, 4), "float64"))),
+        42)
+
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:


### PR DESCRIPTION
See <https://github.com/inducer/grudge/issues/287>.