### PR TITLE
Ensure ArrayContext is not hashable

### DIFF
--- a/arraycontext/context.py
+++ b/arraycontext/context.py
@@ -286,6 +286,9 @@ class ArrayContext(ABC):
         from .fake_numpy import BaseFakeNumpyNamespace
         return BaseFakeNumpyNamespace(self)
 
+    def __hash__(self) -> int:
+        raise TypeError(f"unhashable type: '{type(self).__name__}'")
+
     @abstractmethod
     def empty(self,
               shape: Union[int, Tuple[int, ...]],


### PR DESCRIPTION
Custom objects have some hash based on their `id()`
https://docs.python.org/3/glossary.html#term-hashable

x-ref: inducer/meshmode#354
cc: @kaushikcfd 