### PR TITLE
Fix swapped `map`/`reduce_func` in `test_container_scalar_map`

### DIFF
--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -784,9 +784,9 @@ def test_container_scalar_map(actx_factory):
         result = rec_map_array_container(lambda x: x, ary)
         assert result is not None
 
-        result = map_reduce_array_container(np.shape, lambda x: x, ary)
+        result = map_reduce_array_container(lambda x: x, np.shape, ary)
         assert result is not None
-        result = rec_map_reduce_array_container(np.shape, lambda x: x, ary)
+        result = rec_map_reduce_array_container(lambda x: x, np.shape, ary)
         assert result is not None
 
 


### PR DESCRIPTION
This started (rightfully) failing with numpy 1.24. I'm not even sure what the prior code was trying to accomplish. I'm still not sure I get what it's trying to do now.

cc @alexfikl as the person who last touched that code.