### PR TITLE
Copy `axes` and `tags` in `zeros_like`/`full_like`

### DIFF
--- a/arraycontext/impl/pytato/fake_numpy.py
+++ b/arraycontext/impl/pytato/fake_numpy.py
@@ -73,7 +73,8 @@ class PytatoFakeNumpyNamespace(LoopyBasedFakeNumpyNamespace):
 
     def zeros_like(self, ary):
         def _zeros_like(array):
-            return self._array_context.zeros(array.shape, array.dtype)
+            return self._array_context.zeros(
+                array.shape, array.dtype).copy(axes=array.axes, tags=array.tags)
 
         return self._array_context._rec_map_container(
             _zeros_like, ary, default_scalar=0)
@@ -83,7 +84,8 @@ class PytatoFakeNumpyNamespace(LoopyBasedFakeNumpyNamespace):
 
     def full_like(self, ary, fill_value):
         def _full_like(subary):
-            return pt.full(subary.shape, fill_value, subary.dtype)
+            return pt.full(subary.shape, fill_value, subary.dtype).copy(
+                axes=subary.axes, tags=subary.tags)
 
         return self._array_context._rec_map_container(
             _full_like, ary, default_scalar=fill_value)


### PR DESCRIPTION
Am I doing this right? (As far as I could tell, `pt.zeros`/`pt.full` don't accept `axes` or `tags` directly.)

This makes all of the RHS "uninferred axes" warnings go away in my Y3 prediction `smoke_test` run.

cc @anderson2981