### PR TITLE
tests: fix comparison on numpy 1.25

### DIFF
--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -1311,7 +1311,8 @@ def test_container_equality(actx_factory):
     dc2 = MyContainer(name="yoink", mass=ary_dof, momentum=None, enthalpy=None)
     assert dc != dc2
 
-    assert isinstance(bcast_dc_of_dofs == bcast_dc_of_dofs_2, MyContainerDOFBcast)
+    assert isinstance(actx.np.equal(bcast_dc_of_dofs, bcast_dc_of_dofs_2),
+                      MyContainerDOFBcast)
 
 # }}}
 


### PR DESCRIPTION
Before comparing two `ndarray([DOFArray, DOFArray])` would just return `ndarray([False, False])`, but it doesn't work anymore. Couldn't find an explanation in the release notes as to why that changed.

I changed it to use `actx.np.equal`, but I'm not sure if this was supposed to test `__eq__`?