### PR TITLE
_get_scalar_func_loopy_program: Allow offsets in GlobalArgs

### DIFF
--- a/arraycontext/loopy.py
+++ b/arraycontext/loopy.py
@@ -104,8 +104,10 @@ def _get_scalar_func_loopy_program(actx, c_name, nargs, naxes):
                             var("inp%d" % i)[subscript] for i in range(nargs)]))
                     ],
                 [
-                    lp.GlobalArg("out", dtype=None, shape=lp.auto)] + [
-                        lp.GlobalArg("inp%d" % i, dtype=None, shape=lp.auto)
+                    lp.GlobalArg("out",
+                                 dtype=None, shape=lp.auto, offset=lp.auto)] + [
+                        lp.GlobalArg("inp%d" % i,
+                                     dtype=None, shape=lp.auto, offset=lp.auto)
                         for i in range(nargs)] + [...],
                 name="actx_special_%s" % c_name,
                 tags=(ElementwiseMapKernelTag(),))


### PR DESCRIPTION
Fixes CI failures like this one: https://gitlab.tiker.net/inducer/sumpy/-/jobs/583337#L375. Follow-on to #236.