### PR TITLE
Require pocl 3.1

### DIFF
--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -8,7 +8,8 @@ dependencies:
 - git
 - libhwloc=2
 - numpy
-- pocl
+# pocl 3.1 required for full SVM functionality
+- pocl>=3.1
 - mako
 - pyopencl
 - islpy


### PR DESCRIPTION
Conda started finding solutions with pocl 1.3 for reasons I wasn't able to discover.

E.g. https://github.com/inducer/pytato/actions/runs/6211303235/job/16860360315#step:3:959