### PR TITLE
jax: update config import

### DIFF
--- a/arraycontext/pytest.py
+++ b/arraycontext/pytest.py
@@ -189,7 +189,7 @@ class _PytestEagerJaxArrayContextFactory(PytestArrayContextFactory):
             return False
 
     def __call__(self):
-        from jax.config import config
+        from jax import config
 
         from arraycontext import EagerJAXArrayContext
         config.update("jax_enable_x64", True)
@@ -214,7 +214,7 @@ class _PytestPytatoJaxArrayContextFactory(PytestArrayContextFactory):
             return False
 
     def __call__(self):
-        from jax.config import config
+        from jax import config
 
         from arraycontext import PytatoJAXArrayContext
         config.update("jax_enable_x64", True)


### PR DESCRIPTION
The latest version of jax updated the location of the config object:
https://jax.readthedocs.io/en/latest/changelog.html#jax-0-4-25-feb-26-2024

I think this should work in older versions too, since `jax.config.update` has been there (just the explicit `jax.config.config` object moved)