### PR TITLE
Restore loop inference fallback

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ implementations for:
 - Profiling
 
 ``arraycontext`` started life as an array abstraction for use with the
-`meshmode <https://documen.tician.de/meshmode/>`__ unstrucuted discretization
+`meshmode <https://documen.tician.de/meshmode/>`__ unstructured discretization
 package.
 
 Distributed under the MIT license.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ git+https://github.com/inducer/islpy.git#egg=islpy
 
 git+https://github.com/inducer/loopy.git#egg=loopy
 git+https://github.com/inducer/pytato.git#egg=pytato
+
+git+https://github.com/inducer/meshmode.git#egg=meshmode


### PR DESCRIPTION
This reverts a part of #264 (in particular, parts of https://github.com/inducer/arraycontext/pull/264/commits/9af49ba027b6bf6c9c48a31d28a5a8860869f9bc).

With this PR (and ~~something like https://github.com/illinois-ceesd/mirgecom/pull/898~~ https://github.com/illinois-ceesd/mirgecom/pull/1048), mirgecom is able to run from the main branches of the software stack.

Side note: We carry a similar patch as this PR also in our production branch: https://github.com/illinois-ceesd/arraycontext/commit/bfd22a50808622cdcca8afb415bba20dbaabf058

Related: https://github.com/inducer/meshmode/issues/333 (?)

_Please squash_