### PR TITLE
Ignore mypy false positive

### DIFF
--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -101,7 +101,9 @@ def _preprocess_array_tags(tags: ToTagSetConvertible) -> FrozenSet[Tag]:
                     "was already present.", stacklevel=1)
 
         tags = (
-                (tags | frozenset({PrefixNamed(name_hint.name)}))
+                # NOTE: mypy seems to be confused with `dataclass_transform` so
+                # these don't always work as expected for now..
+                (tags | frozenset({PrefixNamed(name_hint.name)}))  # type: ignore[call-arg]
                 - {name_hint})
 
     return tags


### PR DESCRIPTION
Haven't managed to track down the actual issue, but the error here goes away if `tag_dataclass` is replaced with just `dataclass`. mypy has multiple `dataclass_transform` issues still open, so it's likely not quite ironed out..

Gitlab is passing though: https://gitlab.tiker.net/fikl2/arraycontext/-/pipelines/575042