### PR TITLE
Use Optional and Tuple to test decorator

### DIFF
--- a/arraycontext/impl/pytato/fake_numpy.py
+++ b/arraycontext/impl/pytato/fake_numpy.py
@@ -240,6 +240,6 @@ class PytatoFakeNumpyNamespace(LoopyBasedFakeNumpyNamespace):
         return self.abs(a)
 
     def vdot(self, a: Array, b: Array):
-
         return rec_multimap_array_container(pt.vdot, a, b)
+
     # }}}

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -27,7 +27,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 import logging
-from typing import cast
+from typing import Optional, Tuple, cast  # noqa: UP035
 
 import numpy as np
 import pytest
@@ -63,7 +63,7 @@ def test_dataclass_array_container() -> None:
     class ArrayContainerWithOptional:
         x: np.ndarray
         # Deliberately left as Optional to test compatibility.
-        y: np.ndarray | None
+        y: Optional[np.ndarray]  # noqa: UP045
 
     with pytest.raises(TypeError, match="Field 'y' union contains non-array"):
         # NOTE: cannot have wrapped annotations (here by `Optional`)
@@ -76,7 +76,8 @@ def test_dataclass_array_container() -> None:
     @dataclass
     class ArrayContainerWithTuple:
         x: Array
-        y: tuple[Array, Array]
+        # Deliberately left as Tuple to test compatibility.
+        y: Tuple[Array, Array]  # noqa: UP006
 
     with pytest.raises(TypeError, match="Typing annotation not supported on field 'y'"):
         dataclass_array_container(ArrayContainerWithTuple)


### PR DESCRIPTION
This adds back the `Optional[Array]` that was removed in #299 to fix the ruff warnings.

These are mostly used to test the functionality of the `dataclass_array_container` decorator. Do we want to remove support for old-style `Optional` / `Tuple` / `List` / etc from there instead?

cc @nkoskelo 