### PR TITLE
Attempt to make `BcastUntilActxArray` work for broadcastees that are containers

### DIFF
--- a/arraycontext/container/arithmetic.py
+++ b/arraycontext/container/arithmetic.py
@@ -764,6 +764,10 @@ class BcastUntilActxArray:
                    ],
                    right: ArrayOrContainer
                ) -> ArrayOrContainer:
+        if not isinstance(self.broadcastee, self._stop_types):
+            # Defer to array container broadcast rules
+            return op(self.broadcastee, right)
+
         try:
             serialized = serialize_container(right)
         except NotAnArrayContainerError:
@@ -783,6 +787,10 @@ class BcastUntilActxArray:
                    ],
                    left: ArrayOrContainer
                ) -> ArrayOrContainer:
+        if not isinstance(self.broadcastee, self._stop_types):
+            # Defer to array container broadcast rules
+            return op(left, self.broadcastee)
+
         try:
             serialized = serialize_container(left)
         except NotAnArrayContainerError:

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -1248,6 +1248,20 @@ def test_no_leaf_array_type_broadcasting(actx_factory):
     np.testing.assert_allclose(45, actx.to_numpy(mc_op.mass[0]))
     np.testing.assert_allclose(45, actx.to_numpy(mc_op.momentum[1][0]))
 
+    with pytest.raises(TypeError):
+        mc_op = mc + bcast(DOFArray(actx, (actx_ary,)))
+        np.testing.assert_allclose(45, actx.to_numpy(mc_op.mass[0]))
+
+    mcdofbcast = MyContainerDOFBcast(
+         name="hi",
+         mass=dof_ary,
+         momentum=make_obj_array([dof_ary, dof_ary]),
+         enthalpy=dof_ary)
+
+    mc_op = mcdofbcast + bcast(DOFArray(actx, (actx_ary,)))
+    np.testing.assert_allclose(45, actx.to_numpy(mc_op.mass[0]))
+    np.testing.assert_allclose(45, actx.to_numpy(mc_op.momentum[1][0]))
+
     def _actx_allows_scalar_broadcast(actx):
         if not isinstance(actx, PyOpenCLArrayContext):
             return True

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 from dataclasses import dataclass
+from numbers import Number
 
 import numpy as np
 
@@ -57,6 +58,14 @@ class DOFArray:
 
         if not isinstance(data, tuple):
             raise TypeError("'data' argument must be a tuple")
+
+        if actx is not None:
+            for ary in data:
+                if (
+                        ary is not None
+                        and not isinstance(ary, (
+                            *actx.array_types, np.ndarray, Number))):
+                    raise TypeError(f"invalid data array type {type(ary)}.")
 
         self.array_context = actx
         self.data = data


### PR DESCRIPTION
In some mirgecom examples, `dt` can be a `DOFArray`. When using `_compiled_lsrk45_step` from grudge (which now uses `BcastUntilActxArray` for `h`, etc.), this causes `dt` to broadcast down into the array context arrays of the RHS container, leading to the creation of erroneous nested `DOFArray`s. So it looks like we need to tweak `BcastUntilActxArray` to handle the case of `broadcastee` being an array container.

I took a stab at doing so here. I don't know if this is the right approach, but my hunch is that we should let the container's defined broadcasting behavior take over in this case (mainly because I feel like, e.g., `bcast(Container()) + Container()` ought to be equivalent to `Container() + Container()` and not do any kind of broadcasting inside). Thoughts @inducer, @alexfikl?