### PR TITLE
EagerJAXArrayContext: return mutable numpy array in to_numpy

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -3120,30 +3120,6 @@
             {
                 "code": "reportUnknownVariableType",
                 "range": {
-                    "startColumn": 53,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
                     "startColumn": 19,
                     "endColumn": 27,
                     "lineCount": 3
@@ -3640,14 +3616,6 @@
                 }
             },
             {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnknownParameterType",
                 "range": {
                     "startColumn": 22,
@@ -3660,14 +3628,6 @@
                 "range": {
                     "startColumn": 22,
                     "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
@@ -5334,14 +5294,6 @@
                 "range": {
                     "startColumn": 20,
                     "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 51,
                     "lineCount": 1
                 }
             },

--- a/arraycontext/impl/jax/__init__.py
+++ b/arraycontext/impl/jax/__init__.py
@@ -36,7 +36,7 @@ import numpy as np
 from pytools.tag import ToTagSetConvertible
 
 from arraycontext.container.traversal import rec_map_array_container, with_array_context
-from arraycontext.context import Array, ArrayContext, ArrayOrContainer, ScalarLike
+from arraycontext.context import ArrayContext, ArrayOrContainer, ScalarLike
 
 
 class EagerJAXArrayContext(ArrayContext):
@@ -64,7 +64,7 @@ class EagerJAXArrayContext(ArrayContext):
         return EagerJAXFakeNumpyNamespace(self)
 
     def _rec_map_container(
-            self, func: Callable[[Array], Array], array: ArrayOrContainer,
+            self, func: Callable[[object], object], array: ArrayOrContainer,
             allowed_types: tuple[type, ...] | None = None, *,
             default_scalar: ScalarLike | None = None,
             strict: bool = False) -> ArrayOrContainer:
@@ -101,7 +101,7 @@ class EagerJAXArrayContext(ArrayContext):
     def to_numpy(self, array):
         def _to_numpy(ary):
             import jax
-            return np.copy(jax.device_get(ary))
+            return np.copy(jax.device_get(ary))  # pyright: ignore[reportAny]
 
         return with_array_context(
             self._rec_map_container(_to_numpy, array),

--- a/arraycontext/impl/jax/fake_numpy.py
+++ b/arraycontext/impl/jax/fake_numpy.py
@@ -202,7 +202,7 @@ class EagerJAXFakeNumpyNamespace(BaseFakeNumpyNamespace):
     def sum(self, a, axis=None, dtype=None):
         return rec_map_reduce_array_container(
             sum,
-            partial(jnp.sum, axis=axis, dtype=dtype),
+            partial(jnp.sum, axis=axis, dtype=dtype),  # pyright: ignore[reportArgumentType]
             a)
 
     def amin(self, a, axis=None):


### PR DESCRIPTION
AFAICS, there is no way to make an immutable numpy array mutable again except for copying it.