### PR TITLE
EagerJAXArrayContext: remove stray-ish einsum warning

### DIFF
--- a/arraycontext/impl/jax/__init__.py
+++ b/arraycontext/impl/jax/__init__.py
@@ -132,11 +132,6 @@ class EagerJAXArrayContext(ArrayContext):
 
     def einsum(self, spec, *args, arg_names=None, tagged=()):
         import jax.numpy as jnp
-        if arg_names is not None:
-            from warnings import warn
-            warn("'arg_names' don't bear any significance in "
-                 f"{type(self).__name__}.", stacklevel=2)
-
         return jnp.einsum(spec, *args)
 
     def clone(self):


### PR DESCRIPTION
(arg_names also have no significance in the NumpyArrayContext, where there is also no warning issued.)