### PR TITLE
Remove dataclass from BaseFakeNumpyNamespace

### DIFF
--- a/arraycontext/fake_numpy.py
+++ b/arraycontext/fake_numpy.py
@@ -29,7 +29,6 @@ THE SOFTWARE.
 
 import operator
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 import numpy as np
@@ -66,14 +65,13 @@ if TYPE_CHECKING:
 
 # {{{ BaseFakeNumpyNamespace
 
-@dataclass(frozen=True)
 class BaseFakeNumpyNamespace(ABC):
     _array_context: ArrayContext
     linalg: BaseFakeNumpyLinalgNamespace
 
     def __init__(self, array_context: ArrayContext):
-        object.__setattr__(self, "_array_context", array_context)
-        object.__setattr__(self, "linalg", self._get_fake_numpy_linalg_namespace())
+        self._array_context = array_context
+        self.linalg = self._get_fake_numpy_linalg_namespace()
 
     def _get_fake_numpy_linalg_namespace(self):
         return BaseFakeNumpyLinalgNamespace(self._array_context)


### PR DESCRIPTION
Not quite sure why this was made a dataclass in #322, but none of the subclasses were updated to be dataclasses too? This made some things not get picked up properly (as far as I can tell), like the updated attribute type
```python
class PyOpenCLFakeNumpyNamespace(LoopyBasedFakeNumpyNamespace):
    _array_context: PyOpenCLArrayContext
```