### PR TITLE
Support subclass fields in dataclass_array_container

### DIFF
--- a/arraycontext/container/dataclass.py
+++ b/arraycontext/container/dataclass.py
@@ -163,14 +163,16 @@ def _get_annotated_fields(cls: type) -> Sequence[_Field]:
     from inspect import get_annotations
 
     result = []
-    cls_ann: Mapping[str, type] | None = None
+    field_name_to_type: Mapping[str, type] | None = None
     for field in fields(cls):
         field_type_or_str = field.type
         if isinstance(field_type_or_str, str):
-            if cls_ann is None:
-                cls_ann = get_annotations(cls, eval_str=True)
+            if field_name_to_type is None:
+                field_name_to_type = {}
+                for subcls in cls.__mro__[::-1]:
+                    field_name_to_type.update(get_annotations(subcls, eval_str=True))
 
-            field_type = cls_ann[field.name]
+            field_type = field_name_to_type[field.name]
         else:
             field_type = field_type_or_str
 

--- a/arraycontext/container/dataclass.py
+++ b/arraycontext/container/dataclass.py
@@ -126,20 +126,6 @@ def dataclass_array_container(cls: type[T]) -> type[T]:
 
     def is_array_field(f: _Field) -> bool:
         field_type = f.type
-
-        # NOTE: unions of array containers are treated separately to handle
-        # unions of only array containers, e.g. `Union[np.ndarray, Array]`, as
-        # they can work seamlessly with arithmetic and traversal.
-        #
-        # `Optional[ArrayContainer]` is not allowed, since `None` is not
-        # handled by `with_container_arithmetic`, which is the common case
-        # for current container usage. Other type annotations, e.g.
-        # `Tuple[Container, Container]`, are also not allowed, as they do not
-        # work with `with_container_arithmetic`.
-        #
-        # This is not set in stone, but mostly driven by current usage!
-
-        # NOTE: this should never happen due to using `inspect.get_annotations`
         assert not isinstance(field_type, str)
 
         if not f.init:


### PR DESCRIPTION
`get_annotations` only gets annotations from the current class, but not from any subclasses. This extends that by going through the MRO (in reverse) and gathering all of them up.

Context: `boxtree.Tree` inherits from `boxtree.TreeOfBoxes` and this wouldn't recognize the fields from `TreeOfBoxes`, which are still in the list returned by `fields(Tree)`.