### PR TITLE
Blacklist jax 0.10.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,7 +71,7 @@ Python 3 Conda:
     export EXTRA_INSTALL="scipy"
 
     # Avoid crashes like https://gitlab.tiker.net/inducer/arraycontext/-/jobs/536021
-    sed -i 's/jax/jax !=0.4.6/' .test-conda-env-py3.yml
+    sed -i '/^- jax$/s/$/ !=0.4.6/' .test-conda-env-py3.yml
 
     curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/build-and-test-py-project-within-miniconda.sh
     . ./build-and-test-py-project-within-miniconda.sh

--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -15,3 +15,5 @@ dependencies:
 - islpy
 - pip
 - jax
+# https://github.com/inducer/arraycontext/pull/366
+- jaxlib !=0.10.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
 
 [project.optional-dependencies]
 jax = [
-    "jax>=0.4",
+    # https://github.com/inducer/arraycontext/pull/366
+    "jax>=0.4,!=0.10.2",
 ]
 pyopencl = [
     "islpy>=2024.1",


### PR DESCRIPTION
It seems to have gathered some errors for `atan` of the form
```
[8](https://github.com/inducer/loopy/actions/runs/28729714250/job/85193176285#step:3:1514)
FAILED test_arraycontext.py::test_array_context_np_workalike[<EagerJAXArrayContext>-arctan-1-float64] - assert False
 +  where False = <function allclose at 0x7f0c999e0970>(array([-0.62601646,  1.13303282,  0.        ,  0.        , -0.62601646,\n        1.13303282,  0.        ,  0.        , ...  0.3862027 ,\n        0.58829151,  0.        ,  0.        ,  0.3862027 ,  0.58829151,\n        0.        ,  0.        ]), array([-0.85794504,  0.6265242 ,  0.05130163, -1.2042635 , -0.62601646,\n        1.13303282,  0.38386949, -0.73835904, ...  0.09919862,\n        0.0561592 , -1.07848859, -0.92450816,  0.22791944, -0.6062315 ,\n        0.94313103, -0.78296983]))
```
These are like `[value, value, 0, 0, ...]`, so it looks like some compilation bug. I can't seem to reproduce it locally, and all the failures here are on AMD EPYCs.

We could also implement `atan` in terms of `atan2` for the jax backends, since that seems like it works?